### PR TITLE
Fix installer and logging build issues

### DIFF
--- a/InstallerHelper/CustomAction.cpp
+++ b/InstallerHelper/CustomAction.cpp
@@ -121,12 +121,12 @@ UINT WIXAPI CloseAndReopen(MSIHANDLE hInstaller) {
         _tcscat(build, windows[i].path);
         _tcscat(build, _T(";"));
     }
-    HKEY key;
+    HKEY key = NULL;
     REGSAM access = KEY_SET_VALUE | KEY_CREATE_SUB_KEY | KEY_WOW64_64KEY;
     if(RegOpenKeyEx(HKEY_CURRENT_USER, _T("Software\\QTTabBar\\"), 0, access, &key) == ERROR_SUCCESS) {
         RegSetValueEx(key, _T("TabsOnLastClosedWindow"), 0, REG_SZ, (LPBYTE)build, length + 1);
     }
-    RegCloseKey(key);
+    if(key != NULL) RegCloseKey(key);
     delete[] build;
     ShellExecute(NULL, NULL, windows[0].path, NULL, NULL, SW_SHOWNORMAL);
     return ERROR_SUCCESS;
@@ -153,14 +153,14 @@ UINT WIXAPI CloseAndReopenAndDeletePlugins(MSIHANDLE hInstaller) {
         _tcscat(build, windows[i].path);
         _tcscat(build, _T(";"));
     }
-    HKEY key;
+    HKEY key = NULL;
     // REGSAM access = KEY_SET_VALUE | KEY_CREATE_SUB_KEY | KEY_WOW64_64KEY | KEY_DELETE;
     REGSAM access = KEY_ALL_ACCESS;
     if(RegOpenKeyEx(HKEY_CURRENT_USER, _T("Software\\QTTabBar\\"), 0, access, &key) == ERROR_SUCCESS) {
         RegSetValueEx(key, _T("TabsOnLastClosedWindow"), 0, REG_SZ, (LPBYTE)build, length + 1);
-		RegDeleteKey(key,_T("Plugins\\Paths"));
+                RegDeleteKey(key,_T("Plugins\\Paths"));
     }
-    RegCloseKey(key);
+    if(key != NULL) RegCloseKey(key);
     delete[] build;
     ShellExecute(NULL, NULL, windows[0].path, NULL, NULL, SW_SHOWNORMAL);
     return ERROR_SUCCESS;
@@ -169,7 +169,7 @@ UINT WIXAPI CloseAndReopenAndDeletePlugins(MSIHANDLE hInstaller) {
 
 
 UINT WIXAPI CheckOldVersion(MSIHANDLE hInstaller) {
-    HKEY key;
+    HKEY key = NULL;
     REGSAM access = KEY_QUERY_VALUE | KEY_WOW64_64KEY;
 	// 计算机\HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall
     if(RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{DAD20769-75D8-4C1D-80E3-D545563FE9EF}_is1"), 0, access, &key) == ERROR_SUCCESS) {
@@ -178,7 +178,7 @@ UINT WIXAPI CheckOldVersion(MSIHANDLE hInstaller) {
        return ERROR_SUCCESS;
     }
 	
-    RegCloseKey(key);
+    if(key != NULL) RegCloseKey(key);
 
 	HKEY hKey = NULL; //保存注册表的句柄 
 	DWORD dwIndexs = 0; //需要返回子项的索引 
@@ -202,9 +202,8 @@ UINT WIXAPI CheckOldVersion(MSIHANDLE hInstaller) {
 			DWORD dwSize = sizeof(lpszValue);
 			DWORD dwType = REG_SZ;
 			
-			if (RegOpenKeyEx(HKEY_CLASSES_ROOT, data_Set, NULL, KEY_READ, &hSubKey) == ERROR_SUCCESS)
-			{
-				delete data_Set;
+                        if (RegOpenKeyEx(HKEY_CLASSES_ROOT, data_Set, NULL, KEY_READ, &hSubKey) == ERROR_SUCCESS)
+                        {
 				if (RegQueryValueEx(hSubKey, _T("ProductName"), NULL, &dwType, (LPBYTE)&lpszValue, &dwSize) == ERROR_SUCCESS)
 				{
 					CharLower(lpszValue);

--- a/QTHookLib/main.cpp
+++ b/QTHookLib/main.cpp
@@ -342,8 +342,9 @@ std::wstring GetIniString(std::wstring FilePath, std::wstring AppName, std::wstr
 			return std::wstring();
 		}
 
-		LARGE_INTEGER fileSize{};
-		if (!GetFileSizeEx(pFile, &fileSize)) {
+                LARGE_INTEGER fileSize;
+                fileSize.QuadPart = 0;
+                if (!GetFileSizeEx(pFile, &fileSize)) {
 			CloseHandle(pFile);
 			return std::wstring();
 		}

--- a/QTTabBar/QTUtility2.cs
+++ b/QTTabBar/QTUtility2.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.Diagnostics;
 using System.Drawing;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Media;
@@ -333,7 +334,8 @@ namespace QTTabBarLib {
         
         public static void log(string level, string optional,Dictionary<String, String> dic=null)
         {
-            // ignore 
+            optional = optional ?? string.Empty;
+
             if (null != IGNORES && IGNORES.Length > 0)
             {
                 foreach (var ignore in IGNORES)
@@ -347,30 +349,34 @@ namespace QTTabBarLib {
                 }
             }
 
-            /*
-             var useTime = "";
-             if (null != dateTime)
+            Process process = null;
+            try
             {
-                DateTime oldTime = dateTime;
-                dateTime = DateTime.Now;
-            int threadId = Thread.CurrentThread.ManagedThreadId;
-            DateTime now = DateTime.Now;
-            string useTime = string.Empty;
-            DateTime previous;
-            if (dictTime.TryGetValue(threadId, out previous))
-                useTime = (now - previous).TotalMilliseconds.ToString();
-                dictTime[threadId] = now;
+                process = Process.GetCurrentProcess();
             }
-            else
+            catch
             {
-                dictTime[threadId] = now;
+                // ignore failures to obtain process information
             }
-                    {
-                    .Append(process.Id)
-                    .Append(threadId);
 
-                    .Append(useTime);
-            } 
+            int currentThreadId = Thread.CurrentThread.ManagedThreadId;
+            string useTime = string.Empty;
+            DateTime now = DateTime.Now;
+            lock (dictTime)
+            {
+                if (dictTime.TryGetValue(currentThreadId, out DateTime previous))
+                {
+                    useTime = (now - previous).TotalMilliseconds.ToString(CultureInfo.InvariantCulture);
+                }
+                dictTime[currentThreadId] = now;
+            }
+
+            string appdata = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            string appdataQT = Path.Combine(appdata, "QTTabBar");
+            if (!Directory.Exists(appdataQT))
+            {
+                Directory.CreateDirectory(appdataQT);
+            }
 
             string path = Path.Combine(appdataQT, "QTTabBarException.log");
             var line = new StringBuilder();
@@ -413,18 +419,9 @@ namespace QTTabBarLib {
                     .Append(process.Id);
             }
             // 线程 ID
-            if (cThreadId != null)
-            {
-                line
-                    .Append("\tT:")
-                    .Append(cThreadId);
-            }
-            else if (currentThreadId != null)
-            {
-                line
-                    .Append("\tT:")
-                    .Append(currentThreadId);
-            }
+            line
+                .Append("\tT:")
+                .Append(currentThreadId);
 
             if (!string.IsNullOrEmpty(useTime))
             {


### PR DESCRIPTION
## Summary
- guard registry handles against null before closing in installer custom actions and remove invalid delete call
- initialize file size data using Win32-friendly syntax to avoid C++ local function errors
- rebuild the logging helper to ensure braces are balanced and capture process/thread metadata safely

## Testing
- not run (Windows-specific build environment required)


------
https://chatgpt.com/codex/tasks/task_e_68cf04afd0a08330b09aac0326010319