### PR TITLE
Fix GDI+ min max lookup for QTHookLib

### DIFF
--- a/QTHookLib/main.cpp
+++ b/QTHookLib/main.cpp
@@ -26,6 +26,9 @@
 #include <time.h>
 #include <map>
 
+using std::max;
+using std::min;
+
 //GDI 相关 Using GDI
 #include <comdef.h>
 #include <gdiplus.h>


### PR DESCRIPTION
## Summary
- ensure the GDI+ header sees std::min and std::max by adding using declarations before inclusion

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cf0ba1244c83309492dc2a974b7a89