### PR TITLE
Fix Options13 language compile entry

### DIFF
--- a/QTTabBar/QTTabBar.csproj
+++ b/QTTabBar/QTTabBar.csproj
@@ -306,9 +306,12 @@
     <Compile Include="OptionsDialog\Options11_ButtonBar.xaml.cs">
       <DependentUpon>Options11_ButtonBar.xaml</DependentUpon>
     </Compile>
-    <Compile Include="OptionsDialog\Options12_Plugins.xaml.cs">
-      <DependentUpon>Options12_Plugins.xaml</DependentUpon>
-    </Compile>
+    <Compile Include="OptionsDialog\Options12_Plugins.xaml.cs">
+      <DependentUpon>Options12_Plugins.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="OptionsDialog\Options13_Language.xaml.cs">
+      <DependentUpon>Options13_Language.xaml</DependentUpon>
+    </Compile>
 
       <DependentUpon>Options13_Language.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
## Summary
- add the missing OptionsDialog Options13 language code-behind entry to the QTTabBar project file so the XML compiles correctly

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cf19c3cff08330bf38a82913f1e364