### PR TITLE
Remove duplicate Config.cs compile item

### DIFF
--- a/QTTabBar/QTTabBar.csproj
+++ b/QTTabBar/QTTabBar.csproj
@@ -375,7 +375,6 @@
     </Compile>
     <Compile Include="RebarController.cs" />
     <Compile Include="MiscClasses.cs" />
-    <Compile Include="Config.cs" />
     <Compile Include="Spinner.xaml.cs">
       <DependentUpon>Spinner.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
## Summary
- remove the duplicate `Config.cs` compile include from QTTabBar.csproj to avoid MSBuild duplicate item errors

## Testing
- dotnet build "QTTabBar Rebirth.sln" *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cf20b0ecc08330ad06f7cfbf019732