### PR TITLE
Fix Config out parameter usage for legacy C# compilers

### DIFF
--- a/QTTabBar/Config.cs
+++ b/QTTabBar/Config.cs
@@ -269,7 +269,9 @@ namespace QTTabBarLib {
 
         public static bool Bool(string setting)
         {
-            if (TryGetSettingProperty(setting, out object category, out System.Reflection.PropertyInfo property))
+            object category;
+            System.Reflection.PropertyInfo property;
+            if (TryGetSettingProperty(setting, out category, out property))
             {
                 object value = property.GetValue(category);
                 if (property.PropertyType == typeof(bool))
@@ -293,7 +295,9 @@ namespace QTTabBarLib {
 
         public static int Get(string setting)
         {
-            if (TryGetSettingProperty(setting, out object category, out System.Reflection.PropertyInfo property))
+            object category;
+            System.Reflection.PropertyInfo property;
+            if (TryGetSettingProperty(setting, out category, out property))
             {
                 object value = property.GetValue(category);
                 if (value == null)
@@ -337,7 +341,9 @@ namespace QTTabBarLib {
 
         private static void SetInternal(string setting, object value)
         {
-            if (!TryGetSettingProperty(setting, out object category, out System.Reflection.PropertyInfo property) || !property.CanWrite)
+            object category;
+            System.Reflection.PropertyInfo property;
+            if (!TryGetSettingProperty(setting, out category, out property) || !property.CanWrite)
             {
                 return;
             }


### PR DESCRIPTION
## Summary
- declare local variables for category instances and property metadata before calling `TryGetSettingProperty`
- maintain compatibility with environments targeting older C# versions that do not support inline `out` variable declarations

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf24e3cf2c83309a2a12022f0c26dd