### PR TITLE
Restore QTQuick admin and cleanup cases

### DIFF
--- a/Plugins/QTQuick/QTQuick.cs
+++ b/Plugins/QTQuick/QTQuick.cs
@@ -732,31 +732,34 @@ namespace Qwop {
                                 {
                                     Thread.Sleep( 3000 );
 
-                                    
+
                                     PowerShell.Create().AddCommand("setx")
                                         .AddParameter("JAVA_HOME", selectedPath)
                                         .AddParameter("/M")
                                         .Invoke();
                                 }).Start();*/
                             }
-                            else {
-                            catch (Exception ex) {
-                                QTUtility2.MakeErrorLog(ex);
+                            else
+                            {
+                                MessageBox.Show("未找到 SetHome.exe");
+                            }
                             break;
                         }
 
-                        catch (Exception ex)
+                    case 8:  // 删除 QTTabGroup（启动项）
                         {
-                            QTUtility2.MakeErrorLog(ex);
+                            string startUpFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.Startup);
                             try
                             {
                                 string[] groupFiles = Directory.GetFiles(startUpFolderPath, "*.QTTabGroup");
-                                foreach (string groupFile in groupFiles) {
+                                foreach (string groupFile in groupFiles)
+                                {
                                     File.Delete(groupFile);
                                 }
                             }
-                            catch (Exception e) {
-                               // QTUtility2.MakeErrorLog(e);
+                            catch (Exception ex)
+                            {
+                                QTUtility2.MakeErrorLog(ex);
                             }
                             break;
                         }

--- a/QTTabBar/Config.cs
+++ b/QTTabBar/Config.cs
@@ -269,17 +269,19 @@ namespace QTTabBarLib {
 
         public static bool Bool(string setting)
         {
-            if (TryGetSettingProperty(setting, out object category, out System.Reflection.PropertyInfo property))
+            object category;
+            System.Reflection.PropertyInfo property;
+            if (TryGetSettingProperty(setting, out category, out property))
             {
-                object value = property.GetValue(category);
+                object value = property.GetValue(category, null);
                 if (property.PropertyType == typeof(bool))
                 {
-                    return value is bool boolValue && boolValue;
+                    return value != null && (bool)value;
                 }
 
                 if (property.PropertyType == typeof(int))
                 {
-                    return value is int intValue && intValue != 0;
+                    return value != null && ((int)value) != 0;
                 }
 
                 if (property.PropertyType.IsEnum && value != null)
@@ -293,9 +295,11 @@ namespace QTTabBarLib {
 
         public static int Get(string setting)
         {
-            if (TryGetSettingProperty(setting, out object category, out System.Reflection.PropertyInfo property))
+            object category;
+            System.Reflection.PropertyInfo property;
+            if (TryGetSettingProperty(setting, out category, out property))
             {
-                object value = property.GetValue(category);
+                object value = property.GetValue(category, null);
                 if (value == null)
                 {
                     return 0;
@@ -337,7 +341,9 @@ namespace QTTabBarLib {
 
         private static void SetInternal(string setting, object value)
         {
-            if (!TryGetSettingProperty(setting, out object category, out System.Reflection.PropertyInfo property) || !property.CanWrite)
+            object category;
+            System.Reflection.PropertyInfo property;
+            if (!TryGetSettingProperty(setting, out category, out property) || !property.CanWrite)
             {
                 return;
             }
@@ -362,7 +368,7 @@ namespace QTTabBarLib {
                 convertedValue = System.Convert.ChangeType(value, targetType);
             }
 
-            property.SetValue(category, convertedValue);
+            property.SetValue(category, convertedValue, null);
         }
 
 


### PR DESCRIPTION
## Summary
- ensure the admin launch menu case reports a missing SetHome.exe while preserving its guarded process start logic
- restore the startup QTTabGroup cleanup menu case with exception logging so the switch statement compiles correctly

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf24e3cf2c83309a2a12022f0c26dd