### PR TITLE
Add tag-based folder text coloring for Explorer view and tree

### DIFF
--- a/QTTabBar/ExtendedSysListView32.cs
+++ b/QTTabBar/ExtendedSysListView32.cs
@@ -30,6 +30,7 @@ namespace QTTabBarLib {
         private static SolidBrush sbTagBack;
         private struct TagVisualInfo {
             public bool HasTag;
+            public bool HasPath;
             public Color? TextColor;
         }
         private Dictionary<int, TagVisualInfo> tagInfoCache;
@@ -481,49 +482,52 @@ namespace QTTabBarLib {
                                 (IntPtr)(LVIS.FOCUSED | LVIS.SELECTED | LVIS.DROPHILITED));
 
                         if(!QTUtility.IsXP) {
-                            int num4 = lstColumnFMT[structure.iSubItem];
+                            bool altRowColors = Config.Tweaks.AlternateRowColors && (ShellBrowser.ViewMode == FVM.DETAILS);
                             int itemIndex = (int)structure.nmcd.dwItemSpec;
                             TagVisualInfo tagInfo = GetTagInfo(itemIndex);
-                            bool isTagged = tagInfo.HasTag;
-                            Color? tagColor = tagInfo.TextColor;
                             bool isSelectedState = (iListViewItemState & (LVIS.SELECTED | LVIS.DROPHILITED)) != 0;
-                            structure.clrTextBk = QTUtility2.MakeCOLORREF(Config.Tweaks.AltRowBackgroundColor);
-                            structure.clrText = QTUtility2.MakeCOLORREF(Config.Tweaks.AltRowForegroundColor);
-                            if(!isSelectedState) {
-                                if(tagColor.HasValue) {
-                                    structure.clrText = QTUtility2.MakeCOLORREF(tagColor.Value);
+                            if(altRowColors) {
+                                int num4 = lstColumnFMT[structure.iSubItem];
+                                structure.clrTextBk = QTUtility2.MakeCOLORREF(Config.Tweaks.AltRowBackgroundColor);
+                                structure.clrText = QTUtility2.MakeCOLORREF(Config.Tweaks.AltRowForegroundColor);
+                                bool textChanged = ApplyTagTextColor(ref structure, tagInfo, isSelectedState);
+                                if(!isSelectedState && TagManager.HighlightTagged && tagInfo.HasTag) {
+                                    structure.clrTextBk = QTUtility2.MakeCOLORREF(GetTagBackgroundColor(tagInfo.TextColor));
                                 }
-                                else if(TagManager.DimUntagged && !isTagged) {
-                                    structure.clrText = QTUtility2.MakeCOLORREF(Color.Gray);
+                                if(textChanged || (TagManager.HighlightTagged && tagInfo.HasTag && !isSelectedState)) {
+                                    Marshal.StructureToPtr(structure, msg.LParam, false);
                                 }
-                                if(TagManager.HighlightTagged && isTagged) {
-                                    structure.clrTextBk = QTUtility2.MakeCOLORREF(GetTagBackgroundColor(tagColor));
-                                }
-                            }
-                            Marshal.StructureToPtr(structure, msg.LParam, false);
-                            bool drawingHotItem = (dwItemSpec == GetHotItem());
-                            bool fullRowSel = !Config.Tweaks.ToggleFullRowSelect;
+                                bool drawingHotItem = (dwItemSpec == GetHotItem());
+                                bool fullRowSel = !Config.Tweaks.ToggleFullRowSelect;
 
-                            msg.Result = (IntPtr)(CDRF.NEWFONT);
-                            if(structure.iSubItem == 0 && !drawingHotItem) {
-                                if(iListViewItemState == 0 && (num4 & 0x600) != 0) {
-                                    msg.Result = (IntPtr)(CDRF.NEWFONT | CDRF.NOTIFYPOSTPAINT);
-                                }
-                                else if(iListViewItemState == LVIS.FOCUSED && !fullRowSel) {
-                                    msg.Result = (IntPtr)(CDRF.NEWFONT | CDRF.NOTIFYPOSTPAINT);
-                                }
-                            }
-
-                            if(structure.iSubItem > 0 && (!fullRowSel || !drawingHotItem)) {
-                                if(!fullRowSel || (iListViewItemState & (LVIS.SELECTED | LVIS.DROPHILITED)) == 0) {
-                                    using(Graphics graphics = Graphics.FromHdc(structure.nmcd.hdc)) {
-                                        if(sbAlternate == null ||
-                                           sbAlternate.Color != Config.Tweaks.AltRowBackgroundColor) {
-                                            sbAlternate = new SolidBrush(Config.Tweaks.AltRowBackgroundColor);
-                                        }
-                                        graphics.FillRectangle(sbAlternate, structure.nmcd.rc.ToRectangle());
+                                msg.Result = (IntPtr)(CDRF.NEWFONT);
+                                if(structure.iSubItem == 0 && !drawingHotItem) {
+                                    if(iListViewItemState == 0 && (num4 & 0x600) != 0) {
+                                        msg.Result = (IntPtr)(CDRF.NEWFONT | CDRF.NOTIFYPOSTPAINT);
+                                    }
+                                    else if(iListViewItemState == LVIS.FOCUSED && !fullRowSel) {
+                                        msg.Result = (IntPtr)(CDRF.NEWFONT | CDRF.NOTIFYPOSTPAINT);
                                     }
                                 }
+
+                                if(structure.iSubItem > 0 && (!fullRowSel || !drawingHotItem)) {
+                                    if(!fullRowSel || (iListViewItemState & (LVIS.SELECTED | LVIS.DROPHILITED)) == 0) {
+                                        using(Graphics graphics = Graphics.FromHdc(structure.nmcd.hdc)) {
+                                            if(sbAlternate == null ||
+                                               sbAlternate.Color != Config.Tweaks.AltRowBackgroundColor) {
+                                                sbAlternate = new SolidBrush(Config.Tweaks.AltRowBackgroundColor);
+                                            }
+                                            graphics.FillRectangle(sbAlternate, structure.nmcd.rc.ToRectangle());
+                                        }
+                                    }
+                                }
+                            }
+                            else {
+                                bool textChanged = ApplyTagTextColor(ref structure, tagInfo, isSelectedState);
+                                if(textChanged) {
+                                    Marshal.StructureToPtr(structure, msg.LParam, false);
+                                }
+                                msg.Result = (IntPtr)(textChanged ? CDRF.NEWFONT : CDRF.DODEFAULT);
                             }
                         }
                         else {
@@ -794,6 +798,21 @@ namespace QTTabBarLib {
             }
         }
 
+        private static bool ApplyTagTextColor(ref NMLVCUSTOMDRAW structure, TagVisualInfo tagInfo, bool isSelectedState) {
+            if(isSelectedState) {
+                return false;
+            }
+            if(tagInfo.TextColor.HasValue) {
+                structure.clrText = QTUtility2.MakeCOLORREF(tagInfo.TextColor.Value);
+                return true;
+            }
+            if(TagManager.DimUntagged && tagInfo.HasPath && !tagInfo.HasTag) {
+                structure.clrText = QTUtility2.MakeCOLORREF(Color.Gray);
+                return true;
+            }
+            return false;
+        }
+
         private TagVisualInfo GetTagInfo(int index) {
             if(index < 0) {
                 return default(TagVisualInfo);
@@ -810,6 +829,7 @@ namespace QTTabBarLib {
                 using(IDLWrapper wrapper = ShellBrowser.GetItem(index)) {
                     string path = wrapper != null ? wrapper.Path : null;
                     if(!string.IsNullOrEmpty(path)) {
+                        info.HasPath = true;
                         info.TextColor = TagManager.GetTagColorForPath(path);
                         info.HasTag = info.TextColor.HasValue || TagManager.HasTags(path);
                     }

--- a/QTTabBar/Interop/NMTVCUSTOMDRAW.cs
+++ b/QTTabBar/Interop/NMTVCUSTOMDRAW.cs
@@ -1,0 +1,28 @@
+//    This file is part of QTTabBar, a shell extension for Microsoft
+//    Windows Explorer.
+//    Copyright (C) 2007-2021  Quizo, Paul Accisano
+//
+//    QTTabBar is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    QTTabBar is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with QTTabBar.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Runtime.InteropServices;
+
+namespace QTTabBarLib.Interop {
+    [StructLayout(LayoutKind.Sequential)]
+    public struct NMTVCUSTOMDRAW {
+        public NMCUSTOMDRAW nmcd;
+        public int clrText;
+        public int clrTextBk;
+        public int iLevel;
+    }
+}

--- a/QTTabBar/QTTabBar.csproj
+++ b/QTTabBar/QTTabBar.csproj
@@ -471,6 +471,7 @@
     <Compile Include="Interop\NMITEMACTIVATE.cs" />
     <Compile Include="Interop\NMLISTVIEW.cs" />
     <Compile Include="Interop\NMLVCUSTOMDRAW.cs" />
+    <Compile Include="Interop\NMTVCUSTOMDRAW.cs" />
     <Compile Include="Interop\NMLVDISPINFO.cs" />
     <Compile Include="Interop\NMLVGETINFOTIP.cs" />
     <Compile Include="Interop\NMLVKEYDOWN.cs" />

--- a/QTTabBar/QTTabBarClass.cs
+++ b/QTTabBar/QTTabBarClass.cs
@@ -1638,6 +1638,7 @@ namespace QTTabBarLib {
                 }
                 tabControl1.Invalidate();
                 listView?.RefreshTagColors();
+                treeViewWrapper?.RefreshTagColors();
             }
             catch { }
         }

--- a/QTTabBar/TreeViewWrapper.cs
+++ b/QTTabBar/TreeViewWrapper.cs
@@ -16,6 +16,7 @@
 //    along with QTTabBar.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
@@ -31,6 +32,13 @@ namespace QTTabBarLib {
         private NativeWindowController treeController;
         private NativeWindowController parentController;
         private bool fPreventSelChange;
+        private readonly Dictionary<IntPtr, TagVisualInfo> tagInfoCache = new Dictionary<IntPtr, TagVisualInfo>();
+
+        private struct TagVisualInfo {
+            public bool HasPath;
+            public bool HasTag;
+            public Color? TextColor;
+        }
 
         public TreeViewWrapper(IntPtr hwnd, INameSpaceTreeControl treeControl) {
             QTUtility2.log("TreeViewWrapper init");
@@ -39,6 +47,10 @@ namespace QTTabBarLib {
             treeController.MessageCaptured += TreeControl_MessageCaptured;
             parentController = new NativeWindowController(PInvoke.GetParent(hwnd));
             parentController.MessageCaptured += ParentControl_MessageCaptured;
+        }
+
+        private void InvalidateTagInfoCache() {
+            tagInfoCache.Clear();
         }
 
         private bool HandleClick(Point pt, Keys modifierKeys, bool middle) {
@@ -70,11 +82,95 @@ namespace QTTabBarLib {
             return false;
         }
 
+        private TagVisualInfo GetTagInfo(IntPtr itemHandle, RECT itemRect) {
+            TagVisualInfo info;
+            if(itemHandle == IntPtr.Zero) {
+                return default(TagVisualInfo);
+            }
+            if(tagInfoCache.TryGetValue(itemHandle, out info)) {
+                return info;
+            }
+            info = default(TagVisualInfo);
+            if(treeControl == null) {
+                tagInfoCache[itemHandle] = info;
+                return info;
+            }
+            IShellItem item = null;
+            try {
+                int height = itemRect.bottom - itemRect.top;
+                int centerY = itemRect.top + (height > 0 ? height / 2 : 0);
+                Point pt = new Point(Math.Max(itemRect.left + 4, itemRect.left), centerY);
+                if(treeControl.HitTest(pt, out item) == 0 && item != null) {
+                    IntPtr pidl;
+                    if(PInvoke.SHGetIDListFromObject(item, out pidl) == 0 && pidl != IntPtr.Zero) {
+                        using(IDLWrapper wrapper = new IDLWrapper(pidl)) {
+                            string path = wrapper.Path;
+                            if(!string.IsNullOrEmpty(path)) {
+                                info.HasPath = true;
+                                info.TextColor = TagManager.GetTagColorForPath(path);
+                                info.HasTag = info.TextColor.HasValue || TagManager.HasTags(path);
+                            }
+                        }
+                    }
+                }
+            }
+            catch {
+                info = default(TagVisualInfo);
+            }
+            finally {
+                if(item != null) {
+                    QTUtility2.log("ReleaseComObject item");
+                    Marshal.ReleaseComObject(item);
+                }
+            }
+            tagInfoCache[itemHandle] = info;
+            return info;
+        }
+
+        private static bool ApplyTagTextColor(ref NMTVCUSTOMDRAW draw, TagVisualInfo info) {
+            if(info.TextColor.HasValue) {
+                draw.clrText = QTUtility2.MakeCOLORREF(info.TextColor.Value);
+                return true;
+            }
+            if(TagManager.DimUntagged && info.HasPath && !info.HasTag) {
+                draw.clrText = QTUtility2.MakeCOLORREF(Color.Gray);
+                return true;
+            }
+            return false;
+        }
+
+        private bool HandleCustomDraw(ref Message msg) {
+            try {
+                NMTVCUSTOMDRAW draw = (NMTVCUSTOMDRAW)Marshal.PtrToStructure(msg.LParam, typeof(NMTVCUSTOMDRAW));
+                switch(draw.nmcd.dwDrawStage) {
+                    case CDDS.PREPAINT:
+                        InvalidateTagInfoCache();
+                        msg.Result = (IntPtr)CDRF.NOTIFYITEMDRAW;
+                        return true;
+
+                    case CDDS.ITEMPREPAINT:
+                        msg.Result = (IntPtr)CDRF.DODEFAULT;
+                        bool isSelected = (draw.nmcd.uItemState & 0x0001) != 0; // CDIS_SELECTED
+                        if(!isSelected) {
+                            TagVisualInfo info = GetTagInfo((IntPtr)draw.nmcd.dwItemSpec, draw.nmcd.rc);
+                            if(ApplyTagTextColor(ref draw, info)) {
+                                Marshal.StructureToPtr(draw, msg.LParam, false);
+                            }
+                        }
+                        return true;
+                }
+            }
+            catch {
+            }
+            return false;
+        }
+
         private bool TreeControl_MessageCaptured(ref Message msg) {
             switch(msg.Msg) {
                 case WM.USER:
                     QTUtility2.log("TreeViewWrapper TreeControl_MessageCaptured WM.USER");
                     fPreventSelChange = false;
+                    InvalidateTagInfoCache();
                     break;
 
                 case WM.MBUTTONUP:
@@ -90,6 +186,7 @@ namespace QTTabBarLib {
                         QTUtility2.log("TreeViewWrapper TreeControl_MessageCaptured DESTROY");
                         Marshal.ReleaseComObject(treeControl);
                         treeControl = null;
+                        InvalidateTagInfoCache();
                     }
                     break;
             }
@@ -101,6 +198,12 @@ namespace QTTabBarLib {
                 
                 NMHDR nmhdr = (NMHDR)Marshal.PtrToStructure(msg.LParam, typeof(NMHDR));
                 switch(nmhdr.code) {
+                    case -12: /* NM_CUSTOMDRAW */
+                        if(HandleCustomDraw(ref msg)) {
+                            return true;
+                        }
+                        break;
+
                     case -2: /* NM_CLICK */
                         if(Control.ModifierKeys != Keys.None) {
                             QTUtility2.log("TreeViewWrapper ParentControl_MessageCaptured WM.NOTIFY NM_CLICK");
@@ -128,6 +231,13 @@ namespace QTTabBarLib {
 
         #region IDisposable Members
 
+        public void RefreshTagColors() {
+            InvalidateTagInfoCache();
+            if(treeController != null && treeController.Handle != IntPtr.Zero) {
+                PInvoke.InvalidateRect(treeController.Handle, IntPtr.Zero, true);
+            }
+        }
+
         public void Dispose() {
             if(fDisposed) return;
             if(treeControl != null) {
@@ -135,6 +245,7 @@ namespace QTTabBarLib {
                 Marshal.ReleaseComObject(treeControl);
                 treeControl = null;
             }
+            InvalidateTagInfoCache();
             fDisposed = true;
         }
 


### PR DESCRIPTION
## Summary
- ensure SysListView custom draw always reapplies tag colors even when alternate row coloring is disabled
- hook the navigation pane tree control custom draw to paint tagged folders with their configured tag color and dim untagged paths when requested
- add interop definition for `NMTVCUSTOMDRAW` and refresh tree view visuals when tag metadata changes

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6babe43483308fb419ed2a50dab3