### PR TITLE
Fix options dialog crash and improve tab context menu

### DIFF
--- a/QTTabBar/Config.cs
+++ b/QTTabBar/Config.cs
@@ -23,6 +23,7 @@
 //    along with QTTabBar.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -412,6 +413,86 @@ namespace QTTabBarLib {
             plugin = new _Plugin();
             lang = new _Lang();
             desktop = new _Desktop();
+        }
+
+        public Config Clone() {
+            var clone = new Config();
+            CopyCategory(window, clone.window);
+            CopyCategory(tabs, clone.tabs);
+            CopyCategory(tweaks, clone.tweaks);
+            CopyCategory(tips, clone.tips);
+            CopyCategory(misc, clone.misc);
+            CopyCategory(skin, clone.skin);
+            CopyCategory(bbar, clone.bbar);
+            CopyCategory(mouse, clone.mouse);
+            CopyCategory(keys, clone.keys);
+            CopyCategory(plugin, clone.plugin);
+            CopyCategory(lang, clone.lang);
+            CopyCategory(desktop, clone.desktop);
+            return clone;
+        }
+
+        private static void CopyCategory<T>(T source, T target) where T : class {
+            if(source == null || target == null) return;
+            foreach(PropertyInfo property in typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)) {
+                if(!property.CanRead || !property.CanWrite) continue;
+                object value = property.GetValue(source, null);
+                object cloneValue = CloneValue(value);
+                property.SetValue(target, cloneValue, null);
+            }
+        }
+
+        private static object CloneValue(object value) {
+            if(value == null) return null;
+            Type type = value.GetType();
+
+            if(type.IsValueType || type == typeof(string)) {
+                return value;
+            }
+
+            if(value is Font font) {
+                return font.Clone();
+            }
+
+            if(type.IsArray) {
+                Array sourceArray = (Array)value;
+                Type elementType = type.GetElementType();
+                Array cloneArray = Array.CreateInstance(elementType, sourceArray.Length);
+                for(int i = 0; i < sourceArray.Length; i++) {
+                    cloneArray.SetValue(CloneValue(sourceArray.GetValue(i)), i);
+                }
+                return cloneArray;
+            }
+
+            if(typeof(IDictionary).IsAssignableFrom(type)) {
+                IDictionary sourceDict = (IDictionary)value;
+                IDictionary cloneDict = (IDictionary)Activator.CreateInstance(type);
+                foreach(DictionaryEntry entry in sourceDict) {
+                    cloneDict.Add(CloneValue(entry.Key), CloneValue(entry.Value));
+                }
+                return cloneDict;
+            }
+
+            if(typeof(IList).IsAssignableFrom(type)) {
+                IList sourceList = (IList)value;
+                IList cloneList = (IList)Activator.CreateInstance(type);
+                foreach(object item in sourceList) {
+                    cloneList.Add(CloneValue(item));
+                }
+                return cloneList;
+            }
+
+            if(value is ICloneable cloneable) {
+                return cloneable.Clone();
+            }
+
+            object instance = Activator.CreateInstance(type);
+            foreach(PropertyInfo property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance)) {
+                if(!property.CanRead || !property.CanWrite) continue;
+                object propertyValue = property.GetValue(value, null);
+                property.SetValue(instance, CloneValue(propertyValue), null);
+            }
+            return instance;
         }
 
         [Serializable]

--- a/QTTabBar/OptionsDialog/Options13_Language.xaml.cs
+++ b/QTTabBar/OptionsDialog/Options13_Language.xaml.cs
@@ -354,7 +354,7 @@ namespace QTTabBarLib {
             if ( true != radUseLangFileYes.IsChecked)
             {
                   WorkingConfig.lang.BuiltInLangSelectedIndex = buildinCbx.SelectedIndex;
-                  ConfigManager.LoadedConfig = QTUtility2.DeepClone(WorkingConfig);
+                  ConfigManager.LoadedConfig = (WorkingConfig ?? new Config()).Clone();
                   ConfigManager.WriteConfig();
                   ConfigManager.UpdateConfig();
                     //QTUtility.ValidateTextResources

--- a/QTTabBar/OptionsDialog/OptionsDialog.xaml.cs
+++ b/QTTabBar/OptionsDialog/OptionsDialog.xaml.cs
@@ -179,7 +179,8 @@ namespace QTTabBarLib {
                 int i = 0;
                 tabbedPanel.ItemsSource = new OptionsDialogTab[] {
                     new Options01_Window        { Index = i++},
-                    new Options02_Tabs          { Index = i++},
+                WorkingConfig = (ConfigManager.LoadedConfig ?? new Config()).Clone();
+
                     new Options03_Tweaks        { Index = i++},
                     new Options04_Tooltips      { Index = i++},
                     new Options05_General       { Index = i++},
@@ -310,7 +311,7 @@ namespace QTTabBarLib {
                     {
                         StringBuilder b = new StringBuilder();
 
-                        object po = _configProperty.GetValue(_configObj, null);
+            ConfigManager.LoadedConfig = (WorkingConfig ?? new Config()).Clone();
 
                         if (null != po)
                             if (_configProperty.PropertyType == typeof(String))

--- a/QTTabBar/QTTabBarClass.cs
+++ b/QTTabBar/QTTabBarClass.cs
@@ -5477,6 +5477,10 @@ namespace QTTabBarLib {
                     Rectangle itemBounds = ownerItem.Bounds;
                     Point location = owner.PointToScreen(new Point(itemBounds.Right, itemBounds.Top));
                     shellContextMenu.Open(wrapper, location, owner.Handle, false);
+                    ToolStripDropDown ownerDropDown = owner as ToolStripDropDown;
+                    if(ownerDropDown != null && ownerDropDown.Visible) {
+                        ownerDropDown.Close(ToolStripDropDownCloseReason.CloseCalled);
+                    }
                 }
             }
             catch { }

--- a/QTTabBar/QTabControl.cs
+++ b/QTTabBar/QTabControl.cs
@@ -230,34 +230,67 @@ namespace QTTabBarLib {
 
         public  void InitializeColors()
         {
+            Color activeColor = NormalizeTabTextColor(Config.Skin.TabTextActiveColor);
+            Color inactiveColor = NormalizeTabTextColor(Config.Skin.TabTextInactiveColor);
+            Color hotColor = NormalizeTabTextColor(Config.Skin.TabTextHotColor);
+
             if (QTUtility.InNightMode)
                 this.colorSet = new Color[5]
                 {
-                    Config.Skin.TabTextActiveColor,
-                    Config.Skin.TabTextInactiveColor,
-                    Config.Skin.TabTextActiveColor, // Config.TabHiliteColor,
+                    activeColor,
+                    inactiveColor,
+                    hotColor,
                     ShellColors.TextShadow,
                     ShellColors.Default,
                 };
             else
                 this.colorSet = new Color[5]
                 {
-                    Config.Skin.TabTextActiveColor,
-                    Config.Skin.TabTextInactiveColor,
-                    Config.Skin.TabTextActiveColor, // Config.TabHiliteColor,
+                    activeColor,
+                    inactiveColor,
+                    hotColor,
                     Config.Skin.TabShadActiveColor,
                     Config.Skin.TabShadInactiveColor
                 };
             if (brshActive == null)
             {
-                brshActive = new SolidBrush(this.colorSet[0]);
-                brshInactv = new SolidBrush(this.colorSet[1]);
+                brshActive = new SolidBrush(activeColor);
+                brshInactv = new SolidBrush(inactiveColor);
             }
             else
             {
-                brshActive.Color = this.colorSet[0];
-                brshInactv.Color = this.colorSet[1];
+                brshActive.Color = activeColor;
+                brshInactv.Color = inactiveColor;
             }
+        }
+
+        private static Color NormalizeTabTextColor(Color color)
+        {
+            Color normalized = color;
+            if (normalized.IsEmpty)
+            {
+                return QTUtility.InNightMode ? ShellColors.NightModeTextColor : Color.Black;
+            }
+
+            if (normalized.A == 0 && (normalized.R != 0 || normalized.G != 0 || normalized.B != 0))
+            {
+                normalized = Color.FromArgb(255, normalized);
+            }
+
+            if (QTUtility.InNightMode)
+            {
+                if (normalized.A < 255)
+                {
+                    normalized = Color.FromArgb(255, normalized);
+                }
+
+                if (normalized.GetBrightness() < 0.65f)
+                {
+                    return ShellColors.NightModeTextColor;
+                }
+            }
+
+            return normalized;
         }
 
         public static Color selectedColor(bool fSelected)


### PR DESCRIPTION
## Summary
- replace BinaryFormatter-based config cloning with a manual clone routine and switch the options dialog to use it to prevent crashes
- normalize tab text colours (especially in night mode) so inactive and hot tabs remain readable
- ensure the new “Explorer Context” submenu cleanly surfaces the native folder context menu

## Testing
- not run (build tooling is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68cf6c95bfb88330bb6b1e875681268a