### PR TITLE
feat: enhance tags, tab groups, and git overlays

### DIFF
--- a/Docs/TagColorIslandGitPlan.md
+++ b/Docs/TagColorIslandGitPlan.md
@@ -1,0 +1,91 @@
+# Explorer Visual Enhancements – Architecture Plan
+
+## Context
+The existing codebase already supports per-tag foreground colors for list-view rows and tab captions, maintains tag metadata via `TagManager`, exposes tab grouping state through `TabGroupState`, and surfaces Git repository status text from `GitStatusManager`. However, the current implementation stops short of:
+
+- Allowing users to pick colors while creating or editing tags.
+- Applying tag colors to the navigation tree or ensuring consistent precedence across every surface.
+- Representing grouped tabs as collapsible "islands" with their own layout, drag/drop semantics, and persistent colored rails.
+- Decorating tab icons with visual Git status overlays instead of textual suffixes.
+
+This document captures the architectural plan for extending the platform to cover those gaps while keeping the shell extension resilient.
+
+## 1. Tag Color Selection and Propagation
+
+### 1.1 Data Contracts
+- **Tag metadata** – Introduce a `TagDefinition` record that contains the tag name, optional color, and future flags (e.g., default rail color). `TagManager` will internally replace the parallel `tagAssignments` + `tagColors` dictionaries with a single `Dictionary<string, TagDefinition>` plus a `Dictionary<string, HashSet<string>>` for path assignments.  Backwards compatibility is achieved by continuing to write `tagdefs.tsv` until a migration path is defined.
+- **Tag color cache** – Extend `TagManager` with a `ConcurrentDictionary<string, TagVisualState>` keyed by normalized paths. Each entry stores the effective text color, last refresh timestamp, and a hash of the contributing tags. Consumers (`QTabItem`, list views, tree view) will query this cache to avoid repeated set-lookups during draw cycles.
+- **Notifications** – Replace the current `BroadcastTagChanges()` boolean-only broadcast with a `TagVisualChangedEventArgs` payload that includes affected paths, modified tags, and the new effective color. This allows targeted refreshes instead of invalidating every handle.
+
+### 1.2 UI Surface for Color Picking
+- Extend `TagsForm` to show a color picker (Win32 `CHOOSECOLOR` or custom WPF host) whenever a tag is created or edited. Persist the selection through `TagManager.SetTagColor`.
+- Provide defaults and accessibility fallbacks (e.g., high-contrast palettes) by centralizing options in a new `TagColorPalette` helper.
+
+### 1.3 Applying Colors in Explorer Surfaces
+- **Tabs (`QTabItem`)** – Continue using `UpdateTagColor`, but swap to the cache and respect selection/highlight overrides. When multiple tags apply, enforce deterministic priority: explicit tag-level priority > alphabetical order > fallback color.
+- **Main list views (`ExtendedSysListView32`)** – Use the cached color to avoid repeatedly calling into `TagManager`. Implement a `ListViewTagDecorator` responsible for subscribing to `TagVisualChanged` events and invalidating affected items.
+- **Navigation tree (`SysTreeView32`)** – Hook `NM_CUSTOMDRAW` via `TreeViewWrapper`. The wrapper will:
+  - Map tree nodes to shell items using the existing `INameSpaceTreeControl` reference and `IShellItem.GetDisplayName(SIGDN_DESKTOPABSOLUTEEDITING)`.
+  - Query the tag color cache and apply via `CDRF_NEWFONT` or owner-draw to change `clrText`.
+  - Maintain a lightweight node-to-path map refreshed on `TVN_GETDISPINFO` to minimize COM round-trips.
+- **Selection precedence** – Define shared utilities in `TagVisualState` so all consumers apply the same rules (selected rows use system highlight text, inactive windows dim untagged items when the corresponding option is enabled, etc.).
+
+### 1.4 Persistence and Migration
+- Version `tagdefs.tsv` by appending a header (e.g., `#version=2`). When the loader detects v1 files, it will parse existing entries into `TagDefinition` instances with default priorities.
+- Introduce regression tests for loading/saving definitions and ensuring colors survive round-trips.
+
+## 2. Tab Group “Island” Representation
+
+### 2.1 Core Concepts
+- **Island model** – Create a `TabGroupIsland` class that encapsulates group ID, display color, collapsed state, animation progress, and the ordered list of member tab IDs. Persist this structure in `TabGroupState` so that reopening Explorer sessions restores island layout.
+- **Color source** – Allow groups to reuse tag colors by default (when all members share the same dominant tag) but store an explicit `Color? RailColor` on `TabGroupIsland` for manual overrides.
+
+### 2.2 Layout Pipeline Changes
+- Extend `QTabControl` with a pre-layout pass that walks the tab order, clusters consecutive tabs belonging to the same island, and computes bounding rectangles for:
+  - The expanded island background rectangle.
+  - The collapsed rail rectangle (a narrow strip with the same width as a tab header when hidden).
+- Refactor `DrawTab` so actual tab rendering becomes a child operation inside `DrawIsland`, ensuring consistent padding and z-order. Collapsed islands paint only the rail.
+
+### 2.3 Interaction Model
+- **Collapse/expand** – Introduce hit-testing for the rail rectangle. Clicking toggles the `Collapsed` flag and triggers an animation that slides tabs in/out using existing timer infrastructure (`QAnimator`).
+- **Drag/drop membership** – Extend `HandleMouseMove` and `OnTabDrop` so that when a dragged tab hovers over an island rail, a drop indicator appears. Dropping adds the tab’s group ID to the island (or removes it when dropped outside all islands). Update `TabGroupIsland` and broadcast via `TabGroupStateChanged` events.
+- **Multiple islands** – Support multiple `TabGroupIsland` instances by keeping them in an ordered list aligned with the tab strip. Persist their order and collapsed state.
+
+### 2.4 Persistence & Backwards Compatibility
+- Store island metadata alongside existing group settings in the options file. When loading older configurations without islands, initialize a default island per group with `Collapsed=false` and `RailColor=null`.
+- Ensure serialization occurs through the same option-saving pipeline already used by `TabGroupState` to minimize risk.
+
+## 3. Git Status Icon Overlays
+
+### 3.1 Data and Rendering Contracts
+- Introduce a `GitStatusKind` enum (`Clean`, `Modified`, `Staged`, `Untracked`, `Conflict`, `Unknown`). `GitStatusManager` publishes `(path, GitStatusKind)` updates on its dispatcher thread.
+- Create a `GitIconOverlayManager` responsible for:
+  - Maintaining base icon indices for each tab (`QTabItem.BaseIconIndex`).
+  - Generating overlay bitmaps (16×16, 24×24, 32×32) tinted per status color (green, yellow, red, etc.).
+  - Registering composited images inside `QTUtility.ImageListGlobal` and returning the composite index.
+
+### 3.2 Update Flow
+1. `GitStatusManager` detects a status change and raises an event with the `GitStatusKind`.
+2. `GitIconOverlayManager` computes the overlay key (e.g., `baseIndex|Modified`). If not cached, it lazily composes a new bitmap and inserts it into the shared image list using UI-thread marshaling to satisfy Win32 requirements.
+3. `QTabItem` updates its `ImageIndex`/`ImageKey` on the UI thread and invalidates the tab for repaint.
+
+### 3.3 Performance and Reliability
+- Batch updates by coalescing multiple status changes onto the UI thread dispatcher (`SynchronizationContext.Post`).
+- Dispose of generated bitmaps when Explorer exits to prevent leaking handles.
+- Provide feature toggles in options for users who prefer textual badges.
+
+## 4. Cross-Cutting Concerns
+
+- **Threading** – All UI updates must occur on the Explorer UI thread. Use the existing `ExplorerInterop.RunOnUiThread` helpers where possible.
+- **Testing hooks** – Add unit tests for new serialization logic and overlay key caching. Use integration harnesses (e.g., `TestHost`) to validate tree view coloring and island layout via automation IDs.
+- **Telemetry/logging** – Extend `QTUtility2.log` calls with identifiers (`[TagColor]`, `[Island]`, `[GitOverlay]`) to ease troubleshooting.
+
+## 5. Implementation Phasing
+
+1. Refactor `TagManager` to use the new data contracts, expose color picking UI, and wire caches to tabs/list views.
+2. Implement tree view custom draw and ensure performance remains acceptable (measure paint times before/after).
+3. Introduce the `TabGroupIsland` model, modify layout/draw pipelines, and implement collapse/expand interactions.
+4. Layer in drag/drop membership and persistence for islands.
+5. Build the `GitIconOverlayManager`, integrate with `QTabItem`, and expose configuration options.
+
+Each milestone should ship behind hidden options or feature flags to limit blast radius during rollout.

--- a/QTTabBar/ExtendedSysListView32.cs
+++ b/QTTabBar/ExtendedSysListView32.cs
@@ -31,6 +31,8 @@ namespace QTTabBarLib {
         private struct TagVisualInfo {
             public bool HasTag;
             public Color? TextColor;
+            public string Path;
+            public int VisualHash;
         }
         private Dictionary<int, TagVisualInfo> tagInfoCache;
         private NativeWindowController EditController;
@@ -47,6 +49,10 @@ namespace QTTabBarLib {
         internal ExtendedSysListView32(ShellBrowserEx ShellBrowser, IntPtr hwndShellView, IntPtr hwndListView, IntPtr hwndSubDirTipMessageReflect)
                 : base(ShellBrowser, hwndShellView, hwndListView, hwndSubDirTipMessageReflect) {
             SetStyleFlags();
+            try {
+                TagManager.TagVisualChanged += TagManager_TagVisualChanged;
+            }
+            catch { }
         }
 
         private int CorrectHotItem(int iItem) {
@@ -820,9 +826,12 @@ namespace QTTabBarLib {
             try {
                 using(IDLWrapper wrapper = ShellBrowser.GetItem(index)) {
                     string path = wrapper != null ? wrapper.Path : null;
+                    info.Path = path;
                     if(!string.IsNullOrEmpty(path)) {
-                        info.TextColor = TagManager.GetTagColorForPath(path);
-                        info.HasTag = info.TextColor.HasValue || TagManager.HasTags(path);
+                        TagVisualState state = TagManager.GetVisualState(path);
+                        info.TextColor = state.ForegroundColor;
+                        info.HasTag = state.HasTag;
+                        info.VisualHash = state.VisualHash;
                     }
                 }
             }
@@ -838,10 +847,58 @@ namespace QTTabBarLib {
             return ControlPaint.LightLight(baseColor);
         }
 
+        private void TagManager_TagVisualChanged(object sender, TagVisualChangedEventArgs e) {
+            if(e == null) {
+                e = TagVisualChangedEventArgs.Global;
+            }
+            bool requireRefresh = e.RequiresFullRefresh;
+            if(tagInfoCache != null) {
+                if(e.RequiresFullRefresh) {
+                    if(tagInfoCache.Count > 0) {
+                        tagInfoCache.Clear();
+                    }
+                }
+                else {
+                    List<int> toRemove = null;
+                    foreach(KeyValuePair<int, TagVisualInfo> entry in tagInfoCache) {
+                        string cachedPath = entry.Value.Path;
+                        if(string.IsNullOrEmpty(cachedPath)) {
+                            continue;
+                        }
+                        if(e.AffectsPath(cachedPath)) {
+                            if(toRemove == null) {
+                                toRemove = new List<int>();
+                            }
+                            toRemove.Add(entry.Key);
+                        }
+                    }
+                    if(toRemove != null) {
+                        foreach(int key in toRemove) {
+                            tagInfoCache.Remove(key);
+                        }
+                        requireRefresh = true;
+                    }
+                }
+            }
+            if(requireRefresh && ListViewController != null && ListViewController.Handle != IntPtr.Zero) {
+                PInvoke.InvalidateRect(ListViewController.Handle, IntPtr.Zero, true);
+            }
+        }
+
         private void InvalidateTagInfoCache() {
             if(tagInfoCache != null) {
                 tagInfoCache.Clear();
             }
+        }
+
+        public override void Dispose(bool fDisposing) {
+            if(fDisposing) {
+                try {
+                    TagManager.TagVisualChanged -= TagManager_TagVisualChanged;
+                }
+                catch { }
+            }
+            base.Dispose(fDisposing);
         }
 
         private SolidBrush GetCompareBrush(Color color) {

--- a/QTTabBar/ExtendedSysListView32.cs
+++ b/QTTabBar/ExtendedSysListView32.cs
@@ -466,7 +466,8 @@ namespace QTTabBarLib {
         // �����Զ������
         private bool HandleCustomDraw(ref Message msg) {
             // TODO this needs to be cleaned
-            if(Config.Tweaks.AlternateRowColors && (ShellBrowser.ViewMode == FVM.DETAILS)) {
+            if(ShellBrowser.ViewMode == FVM.DETAILS) {
+                bool enableAlternating = Config.Tweaks.AlternateRowColors;
                 NMLVCUSTOMDRAW structure = (NMLVCUSTOMDRAW)Marshal.PtrToStructure(msg.LParam, typeof(NMLVCUSTOMDRAW));
                 int dwItemSpec = 0;
                 if((ulong)structure.nmcd.dwItemSpec < Int32.MaxValue) {
@@ -487,8 +488,10 @@ namespace QTTabBarLib {
                             bool isTagged = tagInfo.HasTag;
                             Color? tagColor = tagInfo.TextColor;
                             bool isSelectedState = (iListViewItemState & (LVIS.SELECTED | LVIS.DROPHILITED)) != 0;
-                            structure.clrTextBk = QTUtility2.MakeCOLORREF(Config.Tweaks.AltRowBackgroundColor);
-                            structure.clrText = QTUtility2.MakeCOLORREF(Config.Tweaks.AltRowForegroundColor);
+                            Color baseBackground = enableAlternating ? Config.Tweaks.AltRowBackgroundColor : SystemColors.Window;
+                            Color baseForeground = enableAlternating ? Config.Tweaks.AltRowForegroundColor : SystemColors.WindowText;
+                            structure.clrTextBk = QTUtility2.MakeCOLORREF(baseBackground);
+                            structure.clrText = QTUtility2.MakeCOLORREF(baseForeground);
                             if(!isSelectedState) {
                                 if(tagColor.HasValue) {
                                     structure.clrText = QTUtility2.MakeCOLORREF(tagColor.Value);
@@ -517,9 +520,12 @@ namespace QTTabBarLib {
                             if(structure.iSubItem > 0 && (!fullRowSel || !drawingHotItem)) {
                                 if(!fullRowSel || (iListViewItemState & (LVIS.SELECTED | LVIS.DROPHILITED)) == 0) {
                                     using(Graphics graphics = Graphics.FromHdc(structure.nmcd.hdc)) {
-                                        if(sbAlternate == null ||
-                                           sbAlternate.Color != Config.Tweaks.AltRowBackgroundColor) {
-                                            sbAlternate = new SolidBrush(Config.Tweaks.AltRowBackgroundColor);
+                                        Color alternateColor = enableAlternating ? Config.Tweaks.AltRowBackgroundColor : SystemColors.Window;
+                                        if(sbAlternate == null || sbAlternate.Color != alternateColor) {
+                                            if(sbAlternate != null) {
+                                                sbAlternate.Dispose();
+                                            }
+                                            sbAlternate = new SolidBrush(alternateColor);
                                         }
                                         graphics.FillRectangle(sbAlternate, structure.nmcd.rc.ToRectangle());
                                     }
@@ -539,6 +545,7 @@ namespace QTTabBarLib {
                             else {
                                 rc.left += 0x10;
                             }
+                            Color alternateColor = enableAlternating ? Config.Tweaks.AltRowBackgroundColor : SystemColors.Window;
                             bool flag4 = false;
                             bool flag5 = Config.Tweaks.DetailsGridLines;
                             bool flag6 = Config.Tweaks.ToggleFullRowSelect ^ !QTUtility.IsXP;
@@ -555,8 +562,11 @@ namespace QTTabBarLib {
                             IntPtr ptr3 = Marshal.AllocHGlobal(Marshal.SizeOf(lvitem));
                             Marshal.StructureToPtr(lvitem, ptr3, false);
                             PInvoke.SendMessage(ListViewController.Handle, LVM.GETITEM, IntPtr.Zero, ptr3);
-                            if(sbAlternate == null) {
-                                sbAlternate = new SolidBrush(Config.Tweaks.AltRowBackgroundColor);
+                            if(sbAlternate == null || sbAlternate.Color != alternateColor) {
+                                if(sbAlternate != null) {
+                                    sbAlternate.Dispose();
+                                }
+                                sbAlternate = new SolidBrush(alternateColor);
                             }
                             using(Graphics graphics2 = Graphics.FromHdc(structure.nmcd.hdc)) {
                                 Rectangle rect = rc.ToRectangle();
@@ -608,7 +618,8 @@ namespace QTTabBarLib {
                                     }
                                 }
                                 else {
-                                    graphics2.FillRectangle(sbAlternate, rect);
+                                    Brush backgroundBrush = enableAlternating ? (Brush)sbAlternate : SystemBrushes.Window;
+                                    graphics2.FillRectangle(backgroundBrush, rect);
                                 }
                                 if(QTUtility.IsXP && ((structure.iSubItem == 0) || flag6)) {
                                     flag4 = (iListViewItemState & 8) == 8;

--- a/QTTabBar/GitStatusKind.cs
+++ b/QTTabBar/GitStatusKind.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace QTTabBarLib {
+    internal enum GitStatusKind {
+        None = 0,
+        Clean,
+        Modified,
+        Untracked,
+        Mixed,
+        Unknown
+    }
+}

--- a/QTTabBar/GitStatusManager.cs
+++ b/QTTabBar/GitStatusManager.cs
@@ -1,66 +1,106 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.Drawing.Text;
 using System.IO;
 using System.Text;
 using System.Threading;
 
 namespace QTTabBarLib {
     internal static class GitStatusManager {
-        private static readonly Dictionary<string, RepoInfo> Cache = new Dictionary<string, RepoInfo>(StringComparer.OrdinalIgnoreCase);
-        private static readonly object CacheGate = new object();
-        private static readonly TimeSpan RefreshInterval = TimeSpan.FromSeconds(10);
-
-        private class RepoInfo {
+        private sealed class RepoInfo {
             public string Branch;
             public int Modified;
             public int Untracked;
+            public GitStatusKind Status;
             public DateTime LastUpdatedUtc;
         }
 
+        private static readonly Dictionary<string, RepoInfo> Cache = new Dictionary<string, RepoInfo>(StringComparer.OrdinalIgnoreCase);
+        private static readonly object CacheGate = new object();
+        private static readonly object IconGate = new object();
+        private static readonly TimeSpan RefreshInterval = TimeSpan.FromSeconds(10);
+
         public static void UpdateTabBadge(QTTabBarClass bar, QTabItem tab) {
-            if (bar == null || tab == null) return;
+            if(bar == null || tab == null) {
+                return;
+            }
             string path = tab.CurrentPath;
-            if (string.IsNullOrEmpty(path) || path.StartsWith("::")) return;
+            if(string.IsNullOrEmpty(path) || path.StartsWith("::", StringComparison.Ordinal)) {
+                return;
+            }
             ThreadPool.QueueUserWorkItem(_ => {
+                RepoInfo info = null;
                 try {
-                    var info = GetRepoInfo(path);
-                    if (info == null) return;
-                    string badge = FormatBadge(info);
-                    if (string.IsNullOrEmpty(badge)) return;
-                    bar.BeginInvoke(new Action(() => {
-                        try {
-                            if (tab.CurrentPath == path) {
-                                if (!tab.Text.Contains(badge)) {
-                                    tab.Text = tab.Text + " " + badge;
-                                }
-                            }
-                        } catch { }
-                    }));
-                } catch { }
+                    info = GetRepoInfo(path);
+                }
+                catch {
+                    info = null;
+                }
+                GitStatusKind status = info != null ? info.Status : GitStatusKind.None;
+                string branch = info != null ? info.Branch : null;
+                bar.BeginInvoke(new Action(() => {
+                    try {
+                        if(tab.CurrentPath != path) {
+                            return;
+                        }
+                        string overlayKey = null;
+                        if(status != GitStatusKind.None) {
+                            overlayKey = EnsureOverlay(tab.GetBaseImageKey(), status);
+                        }
+                        tab.SetGitStatus(status, overlayKey);
+                        UpdateTooltip(tab, branch, status);
+                    }
+                    catch { }
+                }));
             });
         }
 
-        private static string FormatBadge(RepoInfo info) {
+        private static void UpdateTooltip(QTabItem tab, string branch, GitStatusKind status) {
+            if(tab == null) {
+                return;
+            }
+            string tooltip = tab.ToolTipText;
+            if(status == GitStatusKind.None || string.IsNullOrEmpty(branch)) {
+                tab.ToolTipText = tooltip;
+                return;
+            }
+            string badge = FormatBadge(branch, status);
+            if(string.IsNullOrEmpty(tooltip)) {
+                tab.ToolTipText = badge;
+            }
+            else if(tooltip.IndexOf(badge, StringComparison.OrdinalIgnoreCase) < 0) {
+                tab.ToolTipText = tooltip + Environment.NewLine + badge;
+            }
+        }
+
+        private static string FormatBadge(string branch, GitStatusKind status) {
             var sb = new StringBuilder();
-            sb.Append('[').Append(info.Branch ?? "?");
-            if (info.Modified > 0) sb.Append('*').Append(info.Modified);
-            if (info.Untracked > 0) sb.Append('+').Append(info.Untracked);
-            sb.Append(']');
+            sb.Append("Git: ").Append(branch ?? "?");
+            sb.Append(" (" + status + ")");
             return sb.ToString();
         }
 
         private static RepoInfo GetRepoInfo(string path) {
             string root = FindGitRoot(path);
-            if (root == null) return null;
+            if(root == null) {
+                return null;
+            }
             RepoInfo info;
-            lock (CacheGate) {
-                if (Cache.TryGetValue(root, out info)) {
-                    if (DateTime.UtcNow - info.LastUpdatedUtc < RefreshInterval) return info;
+            lock(CacheGate) {
+                if(Cache.TryGetValue(root, out info)) {
+                    if(DateTime.UtcNow - info.LastUpdatedUtc < RefreshInterval) {
+                        return info;
+                    }
                 }
             }
-            info = QueryGit(root) ?? new RepoInfo { Branch = null, Modified = 0, Untracked = 0, LastUpdatedUtc = DateTime.UtcNow };
-            lock (CacheGate) { Cache[root] = info; }
+            info = QueryGit(root) ?? new RepoInfo { Branch = null, Modified = 0, Untracked = 0, Status = GitStatusKind.Unknown, LastUpdatedUtc = DateTime.UtcNow };
+            lock(CacheGate) {
+                Cache[root] = info;
+            }
             return info;
         }
 
@@ -68,20 +108,147 @@ namespace QTTabBarLib {
             try {
                 string branch = RunGit(root, "rev-parse --abbrev-ref HEAD").Trim();
                 string status = RunGit(root, "status --porcelain");
-                int modified = 0, untracked = 0;
-                using (var sr = new StringReader(status)) {
+                int modified = 0;
+                int untracked = 0;
+                using(StringReader reader = new StringReader(status)) {
                     string line;
-                    while ((line = sr.ReadLine()) != null) {
-                        if (line.StartsWith("??")) untracked++;
-                        else modified++;
+                    while((line = reader.ReadLine()) != null) {
+                        if(line.StartsWith("??", StringComparison.Ordinal)) {
+                            untracked++;
+                        }
+                        else if(line.Length > 0) {
+                            modified++;
+                        }
                     }
                 }
-                return new RepoInfo { Branch = string.IsNullOrEmpty(branch) ? "?" : branch, Modified = modified, Untracked = untracked, LastUpdatedUtc = DateTime.UtcNow };
-            } catch { return null; }
+                RepoInfo info = new RepoInfo {
+                    Branch = string.IsNullOrEmpty(branch) ? "?" : branch,
+                    Modified = modified,
+                    Untracked = untracked,
+                    Status = DetermineStatus(modified, untracked),
+                    LastUpdatedUtc = DateTime.UtcNow
+                };
+                return info;
+            }
+            catch {
+                return null;
+            }
+        }
+
+        private static GitStatusKind DetermineStatus(int modified, int untracked) {
+            if(modified == 0 && untracked == 0) {
+                return GitStatusKind.Clean;
+            }
+            if(modified > 0 && untracked > 0) {
+                return GitStatusKind.Mixed;
+            }
+            if(modified > 0) {
+                return GitStatusKind.Modified;
+            }
+            if(untracked > 0) {
+                return GitStatusKind.Untracked;
+            }
+            return GitStatusKind.Unknown;
+        }
+
+        private static string EnsureOverlay(string baseKey, GitStatusKind status) {
+            if(string.IsNullOrEmpty(baseKey) || QTUtility.ImageListGlobal == null) {
+                return baseKey;
+            }
+            string overlayKey = baseKey + "|git:" + status;
+            if(QTUtility.ImageListGlobal.Images.ContainsKey(overlayKey)) {
+                return overlayKey;
+            }
+            lock(IconGate) {
+                if(QTUtility.ImageListGlobal.Images.ContainsKey(overlayKey)) {
+                    return overlayKey;
+                }
+                Image baseImage = QTUtility.ImageListGlobal.Images.ContainsKey(baseKey)
+                        ? QTUtility.ImageListGlobal.Images[baseKey]
+                        : null;
+                if(baseImage == null) {
+                    return baseKey;
+                }
+                using(Bitmap composed = ComposeOverlay(baseImage, status)) {
+                    if(composed != null) {
+                        QTUtility.ImageListGlobal.Images.Add(overlayKey, composed);
+                    }
+                }
+            }
+            return overlayKey;
+        }
+
+        private static Bitmap ComposeOverlay(Image baseImage, GitStatusKind status) {
+            int width = baseImage.Width;
+            int height = baseImage.Height;
+            if(width <= 0 || height <= 0) {
+                return null;
+            }
+            Bitmap result = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+            using(Graphics g = Graphics.FromImage(result)) {
+                g.CompositingQuality = CompositingQuality.HighQuality;
+                g.InterpolationMode = InterpolationMode.HighQualityBicubic;
+                g.SmoothingMode = SmoothingMode.AntiAlias;
+                g.DrawImage(baseImage, new Rectangle(0, 0, width, height));
+
+                int overlaySize = Math.Max(6, Math.Min(width, height) / 2);
+                Rectangle overlayRect = new Rectangle(width - overlaySize, height - overlaySize, overlaySize, overlaySize);
+                Color fill = GetStatusColor(status);
+                using(SolidBrush brush = new SolidBrush(fill)) {
+                    g.FillEllipse(brush, overlayRect);
+                }
+                using(Pen border = new Pen(Color.White, Math.Max(1f, overlaySize / 6f))) {
+                    g.DrawEllipse(border, overlayRect);
+                }
+                string glyph = GetStatusGlyph(status);
+                if(!string.IsNullOrEmpty(glyph)) {
+                    using(Font font = new Font("Segoe UI Symbol", Math.Max(overlayRect.Width - 1, 6), FontStyle.Bold, GraphicsUnit.Pixel))
+                    using(SolidBrush glyphBrush = new SolidBrush(Color.White)) {
+                        g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
+                        StringFormat format = new StringFormat { Alignment = StringAlignment.Center, LineAlignment = StringAlignment.Center };
+                        g.DrawString(glyph, font, glyphBrush, overlayRect, format);
+                    }
+                }
+            }
+            return result;
+        }
+
+        private static Color GetStatusColor(GitStatusKind status) {
+            switch(status) {
+                case GitStatusKind.Clean:
+                    return Color.FromArgb(76, 175, 80);
+                case GitStatusKind.Modified:
+                    return Color.FromArgb(255, 152, 0);
+                case GitStatusKind.Untracked:
+                    return Color.FromArgb(33, 150, 243);
+                case GitStatusKind.Mixed:
+                    return Color.FromArgb(171, 71, 188);
+                case GitStatusKind.Unknown:
+                    return Color.FromArgb(244, 67, 54);
+                default:
+                    return Color.FromArgb(97, 97, 97);
+            }
+        }
+
+        private static string GetStatusGlyph(GitStatusKind status) {
+            switch(status) {
+                case GitStatusKind.Clean:
+                    return "✓";
+                case GitStatusKind.Modified:
+                    return "!";
+                case GitStatusKind.Untracked:
+                    return "?";
+                case GitStatusKind.Mixed:
+                    return "±";
+                case GitStatusKind.Unknown:
+                    return "!";
+                default:
+                    return null;
+            }
         }
 
         private static string RunGit(string workdir, string args) {
-            var psi = new ProcessStartInfo {
+            ProcessStartInfo psi = new ProcessStartInfo {
                 FileName = "git",
                 Arguments = args,
                 WorkingDirectory = workdir,
@@ -90,23 +257,31 @@ namespace QTTabBarLib {
                 UseShellExecute = false,
                 CreateNoWindow = true
             };
-            using (var p = Process.Start(psi)) {
-                var output = p.StandardOutput.ReadToEnd();
-                p.WaitForExit(2000);
+            using(Process process = Process.Start(psi)) {
+                if(process == null) {
+                    return string.Empty;
+                }
+                string output = process.StandardOutput.ReadToEnd();
+                process.WaitForExit(2000);
                 return output ?? string.Empty;
             }
         }
 
         private static string FindGitRoot(string path) {
             try {
-                var dir = new DirectoryInfo(path);
-                if (!dir.Exists) return null;
-                while (dir != null) {
-                    if (Directory.Exists(Path.Combine(dir.FullName, ".git"))) return dir.FullName;
+                DirectoryInfo dir = new DirectoryInfo(path);
+                if(!dir.Exists) {
+                    return null;
+                }
+                while(dir != null) {
+                    if(Directory.Exists(Path.Combine(dir.FullName, ".git"))) {
+                        return dir.FullName;
+                    }
                     dir = dir.Parent;
                 }
-                return null;
-            } catch { return null; }
+            }
+            catch { }
+            return null;
         }
     }
 }

--- a/QTTabBar/Interop/NMTVCUSTOMDRAW.cs
+++ b/QTTabBar/Interop/NMTVCUSTOMDRAW.cs
@@ -1,0 +1,11 @@
+using System.Runtime.InteropServices;
+
+namespace QTTabBarLib.Interop {
+    [StructLayout(LayoutKind.Sequential)]
+    public struct NMTVCUSTOMDRAW {
+        public NMCUSTOMDRAW nmcd;
+        public int clrText;
+        public int clrTextBk;
+        public int iLevel;
+    }
+}

--- a/QTTabBar/QTTabBar.csproj
+++ b/QTTabBar/QTTabBar.csproj
@@ -467,6 +467,7 @@
     <Compile Include="Interop\MOUSEHOOKSTRUCT.cs" />
     <Compile Include="Interop\MOUSEHOOKSTRUCTEX.cs" />
     <Compile Include="Interop\NMCUSTOMDRAW.cs" />
+    <Compile Include="Interop\NMTVCUSTOMDRAW.cs" />
     <Compile Include="Interop\NMHDR.cs" />
     <Compile Include="Interop\NMITEMACTIVATE.cs" />
     <Compile Include="Interop\NMLISTVIEW.cs" />
@@ -530,6 +531,7 @@
     <Compile Include="OperationLedgerManager.cs" />
     <Compile Include="ShellZip.cs" />
     <Compile Include="GitStatusManager.cs" />
+    <Compile Include="GitStatusKind.cs" />
     <Compile Include="TimelineManager.cs" />
     <Compile Include="SessionSnapshotManager.cs" />
     <Compile Include="TimelineForm.cs">
@@ -553,6 +555,9 @@
     <Compile Include="CompareOverlayManager.cs" />
     <Compile Include="TagManager.cs" />
     <Compile Include="TagsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="TagColorEditorForm.cs">
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="RecentOpenedTabsManager.cs" />

--- a/QTTabBar/QTTabBar.csproj
+++ b/QTTabBar/QTTabBar.csproj
@@ -554,6 +554,8 @@
     </Compile>
     <Compile Include="CompareOverlayManager.cs" />
     <Compile Include="TagManager.cs" />
+    <Compile Include="TagVisualChangedEventArgs.cs" />
+    <Compile Include="TagVisualState.cs" />
     <Compile Include="TagsForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/QTTabBar/QTTabBar.csproj
+++ b/QTTabBar/QTTabBar.csproj
@@ -562,6 +562,7 @@
     <Compile Include="TagColorEditorForm.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="TagColorPalette.cs" />
     <Compile Include="RecentOpenedTabsManager.cs" />
     <Compile Include="SubDirTipForm.cs">
       <SubType>Form</SubType>

--- a/QTTabBar/QTTabBarClass.cs
+++ b/QTTabBar/QTTabBarClass.cs
@@ -1705,6 +1705,7 @@ namespace QTTabBarLib {
                 }
                 tabControl1.Invalidate();
                 listView?.RefreshTagColors();
+                treeViewWrapper?.RefreshTagColors();
             }
             catch { }
         }

--- a/QTTabBar/QTabControl.cs
+++ b/QTTabBar/QTabControl.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
+using System.Linq;
 using System.Windows.Forms;
 using System.Windows.Forms.VisualStyles;
 using QTTabBarLib.Interop;
@@ -93,7 +94,12 @@ namespace QTTabBarLib {
         private const int GROUP_INDICATOR_WIDTH = 12;
         private const int GROUP_INDICATOR_HEIGHT = 12;
         private const int GROUP_INDICATOR_SPACING = 4;
+        private const int GROUP_RAIL_WIDTH = 6;
+        private const int GROUP_ISLAND_PADDING = 6;
         private readonly Dictionary<string, TabGroupState> groupStates = new Dictionary<string, TabGroupState>(StringComparer.OrdinalIgnoreCase);
+        private bool groupingDragActive;
+        private Point groupingDragOrigin;
+        private TabGroupState groupDropTarget;
 
         [ThreadStatic()]
         private static VisualStyleRenderer vsr_LHot;
@@ -1427,6 +1433,11 @@ namespace QTTabBarLib {
                 }
             }
             draggingTab = tabMouseOn;
+            if(e.Button == MouseButtons.Left) {
+                groupingDragOrigin = e.Location;
+                groupingDragActive = false;
+                UpdateGroupDropTarget(null);
+            }
             base.OnMouseDown(e);
         }
 
@@ -1441,12 +1452,34 @@ namespace QTTabBarLib {
             }
             hotTab = null;
             fNowMouseIsOnCloseBtn = fNowMouseIsOnIcon = false;
+            if(groupingDragActive) {
+                UpdateGroupDropTarget(null);
+                groupingDragActive = false;
+            }
             PInvoke.InvalidateRect(Handle, IntPtr.Zero, true);
             base.OnMouseLeave(e);
         }
 
         protected override void OnMouseMove(MouseEventArgs e) {
             int num;
+            if((e.Button & MouseButtons.Left) == MouseButtons.Left && draggingTab != null) {
+                if(!groupingDragActive) {
+                    Rectangle dragRect = new Rectangle(
+                        groupingDragOrigin.X - SystemInformation.DragSize.Width / 2,
+                        groupingDragOrigin.Y - SystemInformation.DragSize.Height / 2,
+                        SystemInformation.DragSize.Width,
+                        SystemInformation.DragSize.Height);
+                    if(!dragRect.Contains(e.Location)) {
+                        groupingDragActive = true;
+                    }
+                }
+                if(groupingDragActive) {
+                    UpdateGroupDropTarget(HitTestGroupSurface(e.Location));
+                }
+            }
+            else if(groupingDragActive) {
+                UpdateGroupDropTarget(null);
+            }
             if(((e.Button == MouseButtons.Right) && !Parent.RectangleToScreen(Bounds).Contains(MousePosition)) && ((ItemDrag != null) && (draggingTab != null))) {
                 ItemDrag(this, new ItemDragEventArgs(e.Button, draggingTab));
             }
@@ -1490,7 +1523,12 @@ namespace QTTabBarLib {
         }
 
         protected override void OnMouseUp(MouseEventArgs e) {
+            QTabItem droppedTab = draggingTab;
+            bool wasGroupingDrag = groupingDragActive;
+            TabGroupState dropTarget = groupDropTarget;
             draggingTab = null;
+            groupingDragActive = false;
+            UpdateGroupDropTarget(null);
             if(fSuppressMouseUp) {
                 fSuppressMouseUp = false;
                 base.OnMouseUp(e);
@@ -1498,6 +1536,9 @@ namespace QTTabBarLib {
             else {
                 int num;
                 QTabItem tabMouseOn = GetTabMouseOn(out num);
+                if(e.Button == MouseButtons.Left && wasGroupingDrag && droppedTab != null) {
+                    HandleGroupDrop(droppedTab, dropTarget);
+                }
                 if(((fDrawCloseButton && (e.Button != MouseButtons.Right)) && ((CloseButtonClicked != null) && (tabMouseOn != null))) && (!tabMouseOn.TabLocked && HitTestOnButtons(tabMouseOn.TabBounds, e.Location, true, num == iSelectedIndex))) {
                     if(e.Button == MouseButtons.Left) {
                         iTabMouseOnButtonsIndex = -1;
@@ -1617,6 +1658,7 @@ namespace QTTabBarLib {
         private void OnPaint_MultipleRow(PaintEventArgs e) {
             CalculateItemRectangle_MultiRows();
             try {
+                DrawGroupIndicators(e.Graphics);
                 QTabItem tabMouseOn = GetTabMouseOn();
                 bool fVisualStyle = !fForceClassic && VisualStyleRenderer.IsSupported;
                 if(fVisualStyle && (vsr_LPressed == null)) {
@@ -1654,7 +1696,6 @@ namespace QTTabBarLib {
                         }
                     }
                 }
-                DrawGroupIndicators(e.Graphics);
                 ShowUpDown(false);
             }
             catch(Exception exception) {
@@ -2209,6 +2250,10 @@ namespace QTTabBarLib {
             }
             int width = GROUP_INDICATOR_WIDTH + GROUP_INDICATOR_SPACING;
             state.AnchorBounds = new Rectangle(x, y, width, height);
+            int railHeight = Math.Max(height - 4, 4);
+            int railX = x + Math.Max((width - GROUP_RAIL_WIDTH) / 2, 0);
+            state.RailBounds = new Rectangle(railX, y + 2, GROUP_RAIL_WIDTH, railHeight);
+            state.IndicatorBounds = state.RailBounds;
             x += width;
         }
 
@@ -2241,7 +2286,11 @@ namespace QTTabBarLib {
             TabGroupState state;
             if(!groupStates.TryGetValue(groupName, out state)) {
                 state = new TabGroupState { Name = groupName };
+                state.AccentColor = ResolveGroupAccent(groupName);
                 groupStates[groupName] = state;
+            }
+            else if(state.AccentColor.IsEmpty) {
+                state.AccentColor = ResolveGroupAccent(groupName);
             }
             foreach(var other in groupStates.Values) {
                 if(other == state) {
@@ -2294,6 +2343,10 @@ namespace QTTabBarLib {
                     continue;
                 }
                 state.Tabs.RemoveAll(tab => tab == null || !tabPages.Contains(tab));
+                state.RailBounds = Rectangle.Empty;
+                state.IslandBounds = Rectangle.Empty;
+                state.IndicatorBounds = Rectangle.Empty;
+                state.DropHighlighted = false;
                 if(state.Tabs.Count == 0) {
                     empty.Add(pair.Key);
                 }
@@ -2358,72 +2411,252 @@ namespace QTTabBarLib {
             state.IsCollapsed = !state.IsCollapsed;
             ApplyGroupCollapseState(state);
             EnsureSelectionForCollapsedGroups();
+            UpdateGroupDropTarget(null);
             Invalidate();
         }
 
         private void UpdateGroupIndicators() {
-            foreach(var state in groupStates.Values) {
-                Rectangle anchor = state.AnchorBounds;
-                if(anchor.Width <= 0 || anchor.Height <= 0) {
-                    state.IndicatorBounds = Rectangle.Empty;
-                    continue;
-                }
-                int indicatorHeight = Math.Min(anchor.Height - 4, GROUP_INDICATOR_HEIGHT);
-                if(indicatorHeight < 6) {
-                    indicatorHeight = Math.Min(anchor.Height - 2, GROUP_INDICATOR_HEIGHT);
-                }
-                int x = anchor.Left + Math.Max((anchor.Width - GROUP_INDICATOR_WIDTH) / 2, 0);
-                int y = anchor.Top + Math.Max((anchor.Height - indicatorHeight) / 2, 0);
-                state.IndicatorBounds = new Rectangle(x, y, GROUP_INDICATOR_WIDTH, indicatorHeight);
-            }
+            UpdateGroupIslandGeometry();
         }
 
         private void DrawGroupIndicators(Graphics g) {
-            UpdateGroupIndicators();
+            DrawGroupIslands(g);
+        }
+
+        private static Color ResolveGroupAccent(string groupName) {
+            if(string.IsNullOrEmpty(groupName)) {
+                return Color.SteelBlue;
+            }
+            unchecked {
+                int hash = 17;
+                foreach(char c in groupName) {
+                    hash = hash * 31 + c;
+                }
+                double hue = (hash & 0x7fffffff) % 360;
+                return ColorFromHsl(hue / 360.0, 0.55, 0.45);
+            }
+        }
+
+        private static Color ColorFromHsl(double h, double s, double l) {
+            double r = l;
+            double g = l;
+            double b = l;
+            if(s != 0) {
+                double q = l < 0.5 ? l * (1 + s) : (l + s - l * s);
+                double p = 2 * l - q;
+                r = HueToRgb(p, q, h + 1.0 / 3.0);
+                g = HueToRgb(p, q, h);
+                b = HueToRgb(p, q, h - 1.0 / 3.0);
+            }
+            return Color.FromArgb(255, (int)Math.Round(r * 255), (int)Math.Round(g * 255), (int)Math.Round(b * 255));
+        }
+
+        private static double HueToRgb(double p, double q, double t) {
+            if(t < 0) {
+                t += 1;
+            }
+            if(t > 1) {
+                t -= 1;
+            }
+            if(t < 1.0 / 6.0) {
+                return p + (q - p) * 6 * t;
+            }
+            if(t < 1.0 / 2.0) {
+                return q;
+            }
+            if(t < 2.0 / 3.0) {
+                return p + (q - p) * (2.0 / 3.0 - t) * 6;
+            }
+            return p;
+        }
+
+        private void DrawGroupIslands(Graphics g) {
+            UpdateGroupIslandGeometry();
             foreach(var state in groupStates.Values) {
-                Rectangle rect = state.IndicatorBounds;
-                if(rect.Width <= 0 || rect.Height <= 0) {
+                if(state == null) {
                     continue;
                 }
+                Rectangle island = state.IslandBounds;
+                Rectangle rail = state.RailBounds;
                 if((iMultipleType == 0) && fNeedToDrawUpDown) {
-                    rect.Offset(iScrollWidth, 0);
+                    if(!island.IsEmpty) {
+                        island.Offset(iScrollWidth, 0);
+                    }
+                    if(!rail.IsEmpty) {
+                        rail.Offset(iScrollWidth, 0);
+                    }
                 }
-                if(rect.Right < 0 || rect.Left > Width) {
+                Color accent = state.AccentColor.IsEmpty ? ResolveGroupAccent(state.Name) : state.AccentColor;
+                if(!state.IsCollapsed && !island.IsEmpty) {
+                    Rectangle background = island;
+                    background.Width = Math.Max(background.Width, 4);
+                    background.Height = Math.Max(background.Height, 4);
+                    Color fillColor = Color.FromArgb(state.DropHighlighted ? 96 : 48, accent);
+                    Color borderColor = Color.FromArgb(160, accent);
+                    using(SolidBrush brush = new SolidBrush(fillColor))
+                    using(Pen pen = new Pen(borderColor, 1f)) {
+                        g.FillRectangle(brush, background);
+                        g.DrawRectangle(pen, background);
+                    }
+                }
+                if(rail.Width <= 0 || rail.Height <= 0) {
                     continue;
                 }
-                bool containsSelected = selectedTabPage != null && state.Tabs.Contains(selectedTabPage);
-                Color baseColor = containsSelected ? Config.Skin.TabTextActiveColor : Config.Skin.TabTextHotColor;
-                Color fill = state.IsCollapsed ? ControlPaint.Dark(baseColor) : baseColor;
-                using(SolidBrush brush = new SolidBrush(fill))
-                using(Pen pen = new Pen(ControlPaint.Dark(fill))) {
-                    g.FillRectangle(brush, rect);
-                    g.DrawRectangle(pen, rect);
+                if(rail.Right < 0 || rail.Left > Width) {
+                    continue;
                 }
-                Point[] triangle;
-                if(state.IsCollapsed) {
-                    triangle = new[] {
-                        new Point(rect.Left + 3, rect.Top + 2),
-                        new Point(rect.Right - 3, rect.Top + rect.Height / 2),
-                        new Point(rect.Left + 3, rect.Bottom - 2)
-                    };
+                DrawGroupRail(g, rail, accent, state.IsCollapsed, state.DropHighlighted);
+            }
+        }
+
+        private void DrawGroupRail(Graphics g, Rectangle rail, Color accent, bool collapsed, bool highlighted) {
+            Color fill = highlighted ? ControlPaint.LightLight(accent) : accent;
+            using(SolidBrush brush = new SolidBrush(fill))
+            using(Pen pen = new Pen(ControlPaint.Dark(fill))) {
+                g.FillRectangle(brush, rail);
+                g.DrawRectangle(pen, rail);
+            }
+            int inset = Math.Max(2, rail.Width / 2);
+            Point[] glyph;
+            if(collapsed) {
+                glyph = new[] {
+                    new Point(rail.Left + inset, rail.Top + rail.Height / 2),
+                    new Point(rail.Right - inset, rail.Top + inset),
+                    new Point(rail.Right - inset, rail.Bottom - inset)
+                };
+            }
+            else {
+                glyph = new[] {
+                    new Point(rail.Right - inset, rail.Top + rail.Height / 2),
+                    new Point(rail.Left + inset, rail.Top + inset),
+                    new Point(rail.Left + inset, rail.Bottom - inset)
+                };
+            }
+            using(SolidBrush glyphBrush = new SolidBrush(Color.White)) {
+                g.FillPolygon(glyphBrush, glyph);
+            }
+        }
+
+        private void UpdateGroupIslandGeometry() {
+            foreach(var state in groupStates.Values) {
+                if(state == null) {
+                    continue;
                 }
-                else {
-                    triangle = new[] {
-                        new Point(rect.Left + 3, rect.Top + 3),
-                        new Point(rect.Right - 3, rect.Top + 3),
-                        new Point(rect.Left + rect.Width / 2, rect.Bottom - 3)
-                    };
+                Rectangle anchor = state.AnchorBounds;
+                Rectangle union = Rectangle.Empty;
+                foreach(QTabItem tab in state.Tabs) {
+                    if(tab == null || tab.CollapsedByGroup) {
+                        continue;
+                    }
+                    Rectangle rect = tab.TabBounds;
+                    if(rect.IsEmpty) {
+                        continue;
+                    }
+                    union = union.IsEmpty ? rect : Rectangle.Union(union, rect);
                 }
-                using(SolidBrush arrowBrush = new SolidBrush(Color.White)) {
-                    g.FillPolygon(arrowBrush, triangle);
+                if(union.IsEmpty) {
+                    state.IslandBounds = Rectangle.Empty;
+                    if(anchor.Width > 0 && anchor.Height > 0) {
+                        int railHeight = Math.Max(anchor.Height - 4, 4);
+                        int railX = anchor.Left + Math.Max((anchor.Width - GROUP_RAIL_WIDTH) / 2, 0);
+                        state.RailBounds = new Rectangle(railX, anchor.Top + 2, GROUP_RAIL_WIDTH, railHeight);
+                    }
+                    else if(state.RailBounds.IsEmpty) {
+                        state.RailBounds = Rectangle.Empty;
+                    }
+                    state.IndicatorBounds = state.RailBounds;
+                    continue;
                 }
+                int islandLeft = Math.Min(anchor.Left, union.Left) - GROUP_ISLAND_PADDING;
+                int islandRight = union.Right + GROUP_ISLAND_PADDING;
+                int islandTop = union.Top + 1;
+                int islandBottom = union.Bottom - 1;
+                state.IslandBounds = new Rectangle(islandLeft, islandTop, Math.Max(islandRight - islandLeft, 4), Math.Max(islandBottom - islandTop, 4));
+                int railXBase = anchor.Width > 0
+                        ? anchor.Left + Math.Max((anchor.Width - GROUP_RAIL_WIDTH) / 2, 0)
+                        : union.Left - GROUP_RAIL_WIDTH - 4;
+                railXBase = Math.Min(railXBase, union.Left - 2);
+                int railHeight = Math.Max(union.Height - 4, 4);
+                state.RailBounds = new Rectangle(railXBase, union.Top + 2, GROUP_RAIL_WIDTH, railHeight);
+                state.IndicatorBounds = state.RailBounds;
+            }
+        }
+
+        private TabGroupState HitTestGroupSurface(Point location) {
+            foreach(var state in groupStates.Values) {
+                if(state == null) {
+                    continue;
+                }
+                Rectangle island = state.IslandBounds;
+                Rectangle rail = state.RailBounds;
+                if((iMultipleType == 0) && fNeedToDrawUpDown) {
+                    if(!island.IsEmpty) {
+                        island.Offset(iScrollWidth, 0);
+                    }
+                    if(!rail.IsEmpty) {
+                        rail.Offset(iScrollWidth, 0);
+                    }
+                }
+                if(!state.IsCollapsed && !island.IsEmpty && island.Contains(location)) {
+                    return state;
+                }
+                if(!rail.IsEmpty && rail.Contains(location)) {
+                    return state;
+                }
+            }
+            return null;
+        }
+
+        private void UpdateGroupDropTarget(TabGroupState target) {
+            if(groupDropTarget == target) {
+                return;
+            }
+            if(groupDropTarget != null) {
+                groupDropTarget.DropHighlighted = false;
+            }
+            groupDropTarget = target;
+            if(groupDropTarget != null) {
+                groupDropTarget.DropHighlighted = true;
+            }
+            Invalidate();
+        }
+
+        private void AddTabToGroup(TabGroupState state, QTabItem tab) {
+            if(state == null || tab == null) {
+                return;
+            }
+            List<QTabItem> members = state.Tabs.Where(t => t != null && tabPages.Contains(t)).ToList();
+            if(!members.Contains(tab)) {
+                members.Add(tab);
+                AssignGroupTabs(state.Name, members);
+            }
+            if(state.IsCollapsed) {
+                state.IsCollapsed = false;
+                ApplyGroupCollapseState(state);
+            }
+            EnsureSelectionForCollapsedGroups();
+            Invalidate();
+        }
+
+        private void HandleGroupDrop(QTabItem tab, TabGroupState target) {
+            if(tab == null) {
+                return;
+            }
+            if(target != null) {
+                AddTabToGroup(target, tab);
+            }
+            else if(!string.IsNullOrEmpty(tab.GroupKey)) {
+                RemoveTabFromGroups(tab);
+                CleanupEmptyGroups();
+                EnsureSelectionForCollapsedGroups();
+                Invalidate();
             }
         }
 
         private bool TryHandleGroupIndicatorClick(Point location) {
-            UpdateGroupIndicators();
+            UpdateGroupIslandGeometry();
             foreach(var state in groupStates.Values) {
-                Rectangle rect = state.IndicatorBounds;
+                Rectangle rect = state.RailBounds;
                 if(rect.Width <= 0 || rect.Height <= 0) {
                     continue;
                 }
@@ -2456,6 +2689,10 @@ namespace QTTabBarLib {
             public bool IsCollapsed;
             public Rectangle AnchorBounds;
             public Rectangle IndicatorBounds;
+            public Rectangle IslandBounds;
+            public Rectangle RailBounds;
+            public Color AccentColor;
+            public bool DropHighlighted;
         }
 
         public sealed class QTabCollection : List<QTabItem> {

--- a/QTTabBar/QTabControl.cs
+++ b/QTTabBar/QTabControl.cs
@@ -100,6 +100,7 @@ namespace QTTabBarLib {
         private bool groupingDragActive;
         private Point groupingDragOrigin;
         private TabGroupState groupDropTarget;
+        private readonly EventHandler<TagVisualChangedEventArgs> tagVisualHandler;
 
         [ThreadStatic()]
         private static VisualStyleRenderer vsr_LHot;
@@ -174,6 +175,12 @@ namespace QTTabBarLib {
             {
                 this.sfTypoGraphic.FormatFlags |= StringFormatFlags.DirectionRightToLeft;
             }
+
+            tagVisualHandler = TagManager_TagVisualChanged;
+            try {
+                TagManager.TagVisualChanged += tagVisualHandler;
+            }
+            catch { }
 
             /*if (QTUtility.InNightMode)
             {
@@ -599,6 +606,12 @@ namespace QTTabBarLib {
             if(bmpCloseBtn_Hot != null) {
                 bmpCloseBtn_Hot.Dispose();
                 bmpCloseBtn_Hot = null;
+            }
+            if(disposing && tagVisualHandler != null) {
+                try {
+                    TagManager.TagVisualChanged -= tagVisualHandler;
+                }
+                catch { }
             }
             if(bmpCloseBtn_Pressed != null) {
                 bmpCloseBtn_Pressed.Dispose();
@@ -2286,11 +2299,7 @@ namespace QTTabBarLib {
             TabGroupState state;
             if(!groupStates.TryGetValue(groupName, out state)) {
                 state = new TabGroupState { Name = groupName };
-                state.AccentColor = ResolveGroupAccent(groupName);
                 groupStates[groupName] = state;
-            }
-            else if(state.AccentColor.IsEmpty) {
-                state.AccentColor = ResolveGroupAccent(groupName);
             }
             foreach(var other in groupStates.Values) {
                 if(other == state) {
@@ -2367,6 +2376,118 @@ namespace QTTabBarLib {
                 state.Tabs.RemoveAll(tab => tab == null || !tabPages.Contains(tab));
                 state.Tabs.Sort((a, b) => tabPages.IndexOf(a).CompareTo(tabPages.IndexOf(b)));
                 ApplyGroupCollapseState(state);
+                UpdateGroupAccent(state);
+            }
+        }
+
+        private bool UpdateGroupAccent(TabGroupState state) {
+            if(state == null) {
+                return false;
+            }
+            Color accent;
+            bool useTagColor = TryResolveSharedTagAccent(state, out accent);
+            if(!useTagColor) {
+                accent = ResolveGroupAccent(state.Name);
+            }
+            if(!state.AccentColor.IsEmpty && ColorsEqual(state.AccentColor, accent)) {
+                return false;
+            }
+            state.AccentColor = accent;
+            return true;
+        }
+
+        private static bool TryResolveSharedTagAccent(TabGroupState state, out Color accent) {
+            accent = Color.Empty;
+            if(state == null || state.Tabs == null || state.Tabs.Count == 0) {
+                return false;
+            }
+            Color? candidate = null;
+            foreach(QTabItem tab in state.Tabs) {
+                if(tab == null) {
+                    continue;
+                }
+                Color? tagColor = tab.TagTextColor;
+                if(!tagColor.HasValue && !string.IsNullOrEmpty(tab.CurrentPath)) {
+                    tagColor = TagManager.GetTagColorForPath(tab.CurrentPath);
+                }
+                if(!tagColor.HasValue) {
+                    return false;
+                }
+                if(!candidate.HasValue) {
+                    candidate = tagColor;
+                    continue;
+                }
+                if(candidate.Value.ToArgb() != tagColor.Value.ToArgb()) {
+                    return false;
+                }
+            }
+            if(candidate.HasValue) {
+                accent = candidate.Value;
+                return true;
+            }
+            return false;
+        }
+
+        private static Color GetGroupAccentColor(TabGroupState state) {
+            if(state != null && !state.AccentColor.IsEmpty) {
+                return state.AccentColor;
+            }
+            string name = state != null ? state.Name : null;
+            return ResolveGroupAccent(name);
+        }
+
+        private static bool ColorsEqual(Color left, Color right) {
+            return left.ToArgb() == right.ToArgb();
+        }
+
+        private void TagManager_TagVisualChanged(object sender, TagVisualChangedEventArgs e) {
+            if(IsDisposed) {
+                return;
+            }
+            if(InvokeRequired) {
+                try {
+                    BeginInvoke(new Action(() => HandleTagVisualChanged(e)));
+                }
+                catch { }
+                return;
+            }
+            HandleTagVisualChanged(e);
+        }
+
+        private void HandleTagVisualChanged(TagVisualChangedEventArgs e) {
+            if(IsDisposed) {
+                return;
+            }
+            bool invalidate = false;
+            foreach(TabGroupState state in groupStates.Values) {
+                if(state == null || state.Tabs == null || state.Tabs.Count == 0) {
+                    continue;
+                }
+                if(e != null && !e.RequiresFullRefresh) {
+                    bool relevant = false;
+                    foreach(QTabItem tab in state.Tabs) {
+                        if(tab == null) {
+                            continue;
+                        }
+                        string path = tab.CurrentPath;
+                        if(string.IsNullOrEmpty(path)) {
+                            continue;
+                        }
+                        if(e.AffectsPath(path)) {
+                            relevant = true;
+                            break;
+                        }
+                    }
+                    if(!relevant) {
+                        continue;
+                    }
+                }
+                if(UpdateGroupAccent(state)) {
+                    invalidate = true;
+                }
+            }
+            if(invalidate) {
+                Invalidate();
             }
         }
 
@@ -2486,7 +2607,7 @@ namespace QTTabBarLib {
                         rail.Offset(iScrollWidth, 0);
                     }
                 }
-                Color accent = state.AccentColor.IsEmpty ? ResolveGroupAccent(state.Name) : state.AccentColor;
+                Color accent = GetGroupAccentColor(state);
                 if(!state.IsCollapsed && !island.IsEmpty) {
                     Rectangle background = island;
                     background.Width = Math.Max(background.Width, 4);
@@ -2648,6 +2769,7 @@ namespace QTTabBarLib {
             else if(!string.IsNullOrEmpty(tab.GroupKey)) {
                 RemoveTabFromGroups(tab);
                 CleanupEmptyGroups();
+                SyncGroupOrder();
                 EnsureSelectionForCollapsedGroups();
                 Invalidate();
             }

--- a/QTTabBar/QTabItem.cs
+++ b/QTTabBar/QTabItem.cs
@@ -62,11 +62,15 @@ namespace QTTabBarLib {
         private Dictionary<string, Address[]> dicSelectedItems;
         private bool fNowSlowTip;
         private string imageKey = string.Empty;
+        [NonSerialized]
+        private string baseImageKey = string.Empty;
         private Stack<LogData> stckHistoryBackward;
         private Stack<LogData> stckHistoryForward;
         private bool tabLocked;
         private string shellToolTip;
         private string titleText;
+        [NonSerialized]
+        private GitStatusKind gitStatus;
         [NonSerialized]
         private QTabControl Owner;
         [NonSerialized]
@@ -101,11 +105,15 @@ namespace QTTabBarLib {
             }
             set {
                 if(Owner != null && Owner.DrawFolderImage && !string.IsNullOrEmpty(value)) {
-                    imageKey = QTUtility.GetImageKey(value, null);
+                    string resolved = QTUtility.GetImageKey(value, null);
+                    baseImageKey = resolved;
+                    imageKey = resolved;
                 }
                 else {
+                    baseImageKey = value;
                     imageKey = value;
                 }
+                gitStatus = GitStatusKind.None;
             }
         }
 
@@ -378,6 +386,38 @@ namespace QTTabBarLib {
                 if(refreshOwner && Owner != null) {
                     Owner.Invalidate(TabBounds);
                 }
+            }
+        }
+
+        internal string GetBaseImageKey() {
+            if(string.IsNullOrEmpty(baseImageKey)) {
+                return imageKey;
+            }
+            return baseImageKey;
+        }
+
+        internal void SetGitStatus(GitStatusKind status, string overlayKey) {
+            if(gitStatus == status) {
+                if(status == GitStatusKind.None) {
+                    if(!string.IsNullOrEmpty(baseImageKey) && imageKey == baseImageKey) {
+                        return;
+                    }
+                }
+                else if(!string.IsNullOrEmpty(overlayKey) && imageKey == overlayKey) {
+                    return;
+                }
+            }
+            gitStatus = status;
+            if(status == GitStatusKind.None || string.IsNullOrEmpty(overlayKey)) {
+                if(!string.IsNullOrEmpty(baseImageKey)) {
+                    imageKey = baseImageKey;
+                }
+            }
+            else {
+                imageKey = overlayKey;
+            }
+            if(Owner != null && Owner.DrawFolderImage) {
+                Owner.Invalidate(TabBounds);
             }
         }
 

--- a/QTTabBar/TagColorEditorForm.cs
+++ b/QTTabBar/TagColorEditorForm.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System.Media;
 using System.Windows.Forms;
 
 namespace QTTabBarLib {
@@ -11,6 +12,7 @@ namespace QTTabBarLib {
         private readonly Button btnClearColor;
         private readonly Button btnOk;
         private readonly Button btnCancel;
+        private readonly ToolTip paletteToolTip;
 
         private readonly Dictionary<string, Color?> initialColors;
         private readonly Dictionary<string, Color?> workingColors;
@@ -19,7 +21,7 @@ namespace QTTabBarLib {
 
         private TagColorEditorForm(IList<string> tags, IDictionary<string, Color?> existingColors) {
             Text = "Tag Colors";
-            ClientSize = new Size(400, 260);
+            ClientSize = new Size(440, 380);
             StartPosition = FormStartPosition.CenterParent;
             FormBorderStyle = FormBorderStyle.FixedDialog;
             MaximizeBox = false;
@@ -27,36 +29,68 @@ namespace QTTabBarLib {
 
             initialColors = new Dictionary<string, Color?>(StringComparer.OrdinalIgnoreCase);
             workingColors = new Dictionary<string, Color?>(StringComparer.OrdinalIgnoreCase);
+            paletteToolTip = new ToolTip();
+
             IEnumerable<string> tagSequence = tags ?? new string[0];
             foreach(string tag in tagSequence) {
                 Color? color = null;
                 if(existingColors != null && existingColors.TryGetValue(tag, out color)) {
-                    // nothing else to do
+                    // Preserve existing value
                 }
                 initialColors[tag] = color;
                 workingColors[tag] = color;
             }
+
+            int margin = 12;
+            int contentWidth = ClientSize.Width - (margin * 2);
 
             lstTags = new ListView {
                 View = View.Details,
                 FullRowSelect = true,
                 HideSelection = false,
                 MultiSelect = true,
-                Left = 12,
-                Top = 12,
-                Width = 380,
-                Height = 200,
+                Left = margin,
+                Top = margin,
+                Width = contentWidth,
+                Height = 190,
                 HeaderStyle = ColumnHeaderStyle.Nonclickable
             };
-            lstTags.Columns.Add("Tag", 220, HorizontalAlignment.Left);
-            lstTags.Columns.Add("Color", 140, HorizontalAlignment.Left);
+            int colorColumnWidth = Math.Max(120, lstTags.Width / 3);
+            lstTags.Columns.Add("Tag", lstTags.Width - colorColumnWidth - 4, HorizontalAlignment.Left);
+            lstTags.Columns.Add("Color", colorColumnWidth, HorizontalAlignment.Left);
             PopulateList();
+
+            Label lblPalette = new Label {
+                Text = "Quick palette:",
+                AutoSize = true,
+                Left = margin,
+                Top = lstTags.Bottom + 8
+            };
+
+            FlowLayoutPanel defaultPalettePanel = CreatePalettePanel(TagColorPalette.GetDefaultPalette(), "Palette color");
+            defaultPalettePanel.Left = margin;
+            defaultPalettePanel.Top = lblPalette.Bottom + 4;
+            defaultPalettePanel.Width = contentWidth;
+
+            Label lblHighContrast = new Label {
+                Text = "High contrast palette:",
+                AutoSize = true,
+                Left = margin,
+                Top = defaultPalettePanel.Bottom + 6
+            };
+
+            FlowLayoutPanel highContrastPanel = CreatePalettePanel(TagColorPalette.GetHighContrastPalette(), "High contrast color");
+            highContrastPanel.Left = margin;
+            highContrastPanel.Top = lblHighContrast.Bottom + 4;
+            highContrastPanel.Width = contentWidth;
+
+            int buttonRowTop = highContrastPanel.Bottom + 12;
 
             btnSetColor = new Button {
                 Text = "Choose Color...",
-                Left = 12,
-                Top = lstTags.Bottom + 8,
-                Width = 120
+                Left = margin,
+                Top = buttonRowTop,
+                Width = 124
             };
             btnSetColor.Click += (sender, args) => ChooseColorForSelection();
 
@@ -64,27 +98,31 @@ namespace QTTabBarLib {
                 Text = "Clear",
                 Left = btnSetColor.Right + 8,
                 Top = btnSetColor.Top,
-                Width = 80
+                Width = 90
             };
             btnClearColor.Click += (sender, args) => ClearColorForSelection();
 
             btnOk = new Button {
                 Text = "OK",
-                Width = 80,
+                Width = 90,
                 DialogResult = DialogResult.OK
             };
             btnCancel = new Button {
                 Text = "Cancel",
-                Width = 80,
+                Width = 90,
                 DialogResult = DialogResult.Cancel
             };
 
-            btnOk.Left = ClientSize.Width - 190;
-            btnOk.Top = ClientSize.Height - 50;
-            btnCancel.Left = btnOk.Right + 10;
-            btnCancel.Top = btnOk.Top;
+            btnCancel.Left = ClientSize.Width - margin - btnCancel.Width;
+            btnCancel.Top = buttonRowTop;
+            btnOk.Left = btnCancel.Left - 10 - btnOk.Width;
+            btnOk.Top = buttonRowTop;
 
             Controls.Add(lstTags);
+            Controls.Add(lblPalette);
+            Controls.Add(defaultPalettePanel);
+            Controls.Add(lblHighContrast);
+            Controls.Add(highContrastPanel);
             Controls.Add(btnSetColor);
             Controls.Add(btnClearColor);
             Controls.Add(btnOk);
@@ -124,6 +162,12 @@ namespace QTTabBarLib {
             using(ColorDialog dialog = new ColorDialog { FullOpen = true }) {
                 if(lastChosenColor.HasValue) {
                     dialog.Color = lastChosenColor.Value;
+                }
+                else {
+                    Color? suggestion = TagColorPalette.SuggestColor(workingColors.Values);
+                    if(suggestion.HasValue) {
+                        dialog.Color = suggestion.Value;
+                    }
                 }
                 if(dialog.ShowDialog(this) != DialogResult.OK) {
                     return;
@@ -183,5 +227,79 @@ namespace QTTabBarLib {
             Color c = color.Value;
             return "#" + c.R.ToString("X2") + c.G.ToString("X2") + c.B.ToString("X2");
         }
+
+        private FlowLayoutPanel CreatePalettePanel(IEnumerable<Color> palette, string accessiblePrefix) {
+            FlowLayoutPanel panel = new FlowLayoutPanel {
+                Height = 36,
+                AutoSize = false,
+                WrapContents = false,
+                AutoScroll = true,
+                Margin = new Padding(0),
+                Padding = new Padding(0)
+            };
+            foreach(Color color in palette ?? Enumerable.Empty<Color>()) {
+                Button button = CreatePaletteButton(color, accessiblePrefix);
+                panel.Controls.Add(button);
+            }
+            return panel;
+        }
+
+        private Button CreatePaletteButton(Color color, string accessiblePrefix) {
+            Button button = new Button {
+                Width = 28,
+                Height = 28,
+                Margin = new Padding(2),
+                BackColor = color,
+                FlatStyle = FlatStyle.Flat,
+                Tag = color,
+                UseVisualStyleBackColor = false,
+                Text = string.Empty
+            };
+            button.FlatAppearance.BorderSize = 1;
+            button.FlatAppearance.BorderColor = ControlPaint.Dark(color);
+            button.AccessibleName = accessiblePrefix + " " + ColorToDisplay(color);
+            paletteToolTip.SetToolTip(button, ColorToDisplay(color));
+            button.Click += PaletteButton_Click;
+            return button;
+        }
+
+        private void PaletteButton_Click(object sender, EventArgs e) {
+            Button button = sender as Button;
+            if(button == null) {
+                return;
+            }
+            Color color = (Color)button.Tag;
+            ApplyPaletteColor(color);
+        }
+
+        private void ApplyPaletteColor(Color color) {
+            if(lstTags.SelectedItems.Count == 0) {
+                try {
+                    SystemSounds.Beep.Play();
+                }
+                catch { }
+                lastChosenColor = color;
+                return;
+            }
+            lastChosenColor = color;
+            foreach(ListViewItem item in lstTags.SelectedItems) {
+                string tag = item.Tag as string;
+                if(string.IsNullOrEmpty(tag)) {
+                    continue;
+                }
+                workingColors[tag] = color;
+                item.SubItems[1].Text = ColorToDisplay(color);
+            }
+        }
+
+        protected override void Dispose(bool disposing) {
+            if(disposing) {
+                if(paletteToolTip != null) {
+                    paletteToolTip.Dispose();
+                }
+            }
+            base.Dispose(disposing);
+        }
     }
 }
+

--- a/QTTabBar/TagColorEditorForm.cs
+++ b/QTTabBar/TagColorEditorForm.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace QTTabBarLib {
+    internal sealed class TagColorEditorForm : Form {
+        private readonly ListView lstTags;
+        private readonly Button btnSetColor;
+        private readonly Button btnClearColor;
+        private readonly Button btnOk;
+        private readonly Button btnCancel;
+
+        private readonly Dictionary<string, Color?> initialColors;
+        private readonly Dictionary<string, Color?> workingColors;
+
+        private static Color? lastChosenColor;
+
+        private TagColorEditorForm(IList<string> tags, IDictionary<string, Color?> existingColors) {
+            Text = "Tag Colors";
+            ClientSize = new Size(400, 260);
+            StartPosition = FormStartPosition.CenterParent;
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+
+            initialColors = new Dictionary<string, Color?>(StringComparer.OrdinalIgnoreCase);
+            workingColors = new Dictionary<string, Color?>(StringComparer.OrdinalIgnoreCase);
+            IEnumerable<string> tagSequence = tags ?? new string[0];
+            foreach(string tag in tagSequence) {
+                Color? color = null;
+                if(existingColors != null && existingColors.TryGetValue(tag, out color)) {
+                    // nothing else to do
+                }
+                initialColors[tag] = color;
+                workingColors[tag] = color;
+            }
+
+            lstTags = new ListView {
+                View = View.Details,
+                FullRowSelect = true,
+                HideSelection = false,
+                MultiSelect = true,
+                Left = 12,
+                Top = 12,
+                Width = 380,
+                Height = 200,
+                HeaderStyle = ColumnHeaderStyle.Nonclickable
+            };
+            lstTags.Columns.Add("Tag", 220, HorizontalAlignment.Left);
+            lstTags.Columns.Add("Color", 140, HorizontalAlignment.Left);
+            PopulateList();
+
+            btnSetColor = new Button {
+                Text = "Choose Color...",
+                Left = 12,
+                Top = lstTags.Bottom + 8,
+                Width = 120
+            };
+            btnSetColor.Click += (sender, args) => ChooseColorForSelection();
+
+            btnClearColor = new Button {
+                Text = "Clear",
+                Left = btnSetColor.Right + 8,
+                Top = btnSetColor.Top,
+                Width = 80
+            };
+            btnClearColor.Click += (sender, args) => ClearColorForSelection();
+
+            btnOk = new Button {
+                Text = "OK",
+                Width = 80,
+                DialogResult = DialogResult.OK
+            };
+            btnCancel = new Button {
+                Text = "Cancel",
+                Width = 80,
+                DialogResult = DialogResult.Cancel
+            };
+
+            btnOk.Left = ClientSize.Width - 190;
+            btnOk.Top = ClientSize.Height - 50;
+            btnCancel.Left = btnOk.Right + 10;
+            btnCancel.Top = btnOk.Top;
+
+            Controls.Add(lstTags);
+            Controls.Add(btnSetColor);
+            Controls.Add(btnClearColor);
+            Controls.Add(btnOk);
+            Controls.Add(btnCancel);
+
+            AcceptButton = btnOk;
+            CancelButton = btnCancel;
+        }
+
+        internal static bool TryEditColors(IWin32Window owner, IList<string> tags, IDictionary<string, Color?> existingColors, out Dictionary<string, Color?> result) {
+            using(TagColorEditorForm form = new TagColorEditorForm(tags, existingColors)) {
+                DialogResult dialogResult = form.ShowDialog(owner);
+                if(dialogResult == DialogResult.OK) {
+                    result = form.BuildResult();
+                    return true;
+                }
+            }
+            result = null;
+            return false;
+        }
+
+        private void PopulateList() {
+            lstTags.BeginUpdate();
+            lstTags.Items.Clear();
+            foreach(KeyValuePair<string, Color?> pair in workingColors.OrderBy(p => p.Key, StringComparer.OrdinalIgnoreCase)) {
+                ListViewItem item = new ListViewItem(pair.Key) { Tag = pair.Key };
+                item.SubItems.Add(ColorToDisplay(pair.Value));
+                lstTags.Items.Add(item);
+            }
+            lstTags.EndUpdate();
+        }
+
+        private void ChooseColorForSelection() {
+            if(lstTags.SelectedItems.Count == 0) {
+                return;
+            }
+            using(ColorDialog dialog = new ColorDialog { FullOpen = true }) {
+                if(lastChosenColor.HasValue) {
+                    dialog.Color = lastChosenColor.Value;
+                }
+                if(dialog.ShowDialog(this) != DialogResult.OK) {
+                    return;
+                }
+                lastChosenColor = dialog.Color;
+                foreach(ListViewItem item in lstTags.SelectedItems) {
+                    string tag = item.Tag as string;
+                    if(tag == null) {
+                        continue;
+                    }
+                    workingColors[tag] = dialog.Color;
+                    item.SubItems[1].Text = ColorToDisplay(dialog.Color);
+                }
+            }
+        }
+
+        private void ClearColorForSelection() {
+            if(lstTags.SelectedItems.Count == 0) {
+                return;
+            }
+            foreach(ListViewItem item in lstTags.SelectedItems) {
+                string tag = item.Tag as string;
+                if(tag == null) {
+                    continue;
+                }
+                workingColors[tag] = null;
+                item.SubItems[1].Text = ColorToDisplay(null);
+            }
+        }
+
+        private Dictionary<string, Color?> BuildResult() {
+            Dictionary<string, Color?> changes = new Dictionary<string, Color?>(StringComparer.OrdinalIgnoreCase);
+            foreach(KeyValuePair<string, Color?> pair in workingColors) {
+                Color? initial = null;
+                initialColors.TryGetValue(pair.Key, out initial);
+                if(!ColorsEqual(initial, pair.Value)) {
+                    changes[pair.Key] = pair.Value;
+                }
+            }
+            return changes;
+        }
+
+        private static bool ColorsEqual(Color? first, Color? second) {
+            if(!first.HasValue && !second.HasValue) {
+                return true;
+            }
+            if(first.HasValue != second.HasValue) {
+                return false;
+            }
+            return first.Value.ToArgb() == second.Value.ToArgb();
+        }
+
+        private static string ColorToDisplay(Color? color) {
+            if(!color.HasValue) {
+                return "None";
+            }
+            Color c = color.Value;
+            return "#" + c.R.ToString("X2") + c.G.ToString("X2") + c.B.ToString("X2");
+        }
+    }
+}

--- a/QTTabBar/TagColorPalette.cs
+++ b/QTTabBar/TagColorPalette.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+
+namespace QTTabBarLib {
+    internal static class TagColorPalette {
+        private static readonly Color[] DefaultPalette = new[] {
+            ColorTranslator.FromHtml("#F44336"),
+            ColorTranslator.FromHtml("#E91E63"),
+            ColorTranslator.FromHtml("#9C27B0"),
+            ColorTranslator.FromHtml("#673AB7"),
+            ColorTranslator.FromHtml("#3F51B5"),
+            ColorTranslator.FromHtml("#03A9F4"),
+            ColorTranslator.FromHtml("#009688"),
+            ColorTranslator.FromHtml("#4CAF50"),
+            ColorTranslator.FromHtml("#8BC34A"),
+            ColorTranslator.FromHtml("#CDDC39"),
+            ColorTranslator.FromHtml("#FFC107"),
+            ColorTranslator.FromHtml("#FF9800"),
+            ColorTranslator.FromHtml("#FF5722")
+        };
+
+        private static readonly Color[] HighContrastPalette = new[] {
+            Color.Black,
+            Color.White,
+            ColorTranslator.FromHtml("#0D47A1"),
+            ColorTranslator.FromHtml("#1B5E20"),
+            ColorTranslator.FromHtml("#B71C1C"),
+            ColorTranslator.FromHtml("#004D40"),
+            ColorTranslator.FromHtml("#F57F17"),
+            ColorTranslator.FromHtml("#4A148C")
+        };
+
+        internal static IEnumerable<Color> GetDefaultPalette() {
+            return DefaultPalette;
+        }
+
+        internal static IEnumerable<Color> GetHighContrastPalette() {
+            return HighContrastPalette;
+        }
+
+        internal static Color? SuggestColor(IEnumerable<Color?> existingColors) {
+            HashSet<int> used = new HashSet<int>();
+            if(existingColors != null) {
+                foreach(Color? color in existingColors) {
+                    if(color.HasValue) {
+                        used.Add(color.Value.ToArgb());
+                    }
+                }
+            }
+
+            foreach(Color color in DefaultPalette) {
+                if(!used.Contains(color.ToArgb())) {
+                    return color;
+                }
+            }
+
+            foreach(Color color in HighContrastPalette) {
+                if(!used.Contains(color.ToArgb())) {
+                    return color;
+                }
+            }
+
+            if(DefaultPalette.Length > 0) {
+                return DefaultPalette[0];
+            }
+            if(HighContrastPalette.Length > 0) {
+                return HighContrastPalette[0];
+            }
+            return null;
+        }
+
+        internal static IEnumerable<Color> EnumerateAll() {
+            return DefaultPalette.Concat(HighContrastPalette).Distinct(new ColorEqualityComparer());
+        }
+
+        private sealed class ColorEqualityComparer : IEqualityComparer<Color> {
+            public bool Equals(Color x, Color y) {
+                return x.ToArgb() == y.ToArgb();
+            }
+
+            public int GetHashCode(Color obj) {
+                return obj.ToArgb();
+            }
+        }
+    }
+}
+

--- a/QTTabBar/TagManager.cs
+++ b/QTTabBar/TagManager.cs
@@ -15,10 +15,13 @@ namespace QTTabBarLib {
         private static readonly object Gate = new object();
 
         private static Dictionary<string, HashSet<string>> tagAssignments;
-        private static Dictionary<string, Color> tagColors;
+        private static Dictionary<string, TagDefinition> tagDefinitions;
+        private static Dictionary<string, TagVisualState> visualCache;
 
         private static bool highlightTagged;
         private static bool dimUntagged;
+
+        internal static event EventHandler<TagVisualChangedEventArgs> TagVisualChanged;
 
         public static bool HighlightTagged {
             get { return highlightTagged; }
@@ -27,7 +30,7 @@ namespace QTTabBarLib {
                     return;
                 }
                 highlightTagged = value;
-                BroadcastTagChanges();
+                BroadcastTagChanges(TagVisualChangedEventArgs.Global);
             }
         }
 
@@ -38,22 +41,28 @@ namespace QTTabBarLib {
                     return;
                 }
                 dimUntagged = value;
-                BroadcastTagChanges();
+                BroadcastTagChanges(TagVisualChangedEventArgs.Global);
             }
         }
 
         private static void Ensure() {
-            if(tagAssignments != null) return;
+            if(tagAssignments != null) {
+                return;
+            }
             lock(Gate) {
-                if(tagAssignments != null) return;
+                if(tagAssignments != null) {
+                    return;
+                }
                 tagAssignments = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
-                tagColors = new Dictionary<string, Color>(StringComparer.OrdinalIgnoreCase);
+                tagDefinitions = new Dictionary<string, TagDefinition>(StringComparer.OrdinalIgnoreCase);
+                visualCache = new Dictionary<string, TagVisualState>(StringComparer.OrdinalIgnoreCase);
                 try {
                     Directory.CreateDirectory(DirectoryPath);
                 }
                 catch { }
                 LoadAssignments();
                 LoadDefinitions();
+                RebuildVisualCache();
             }
         }
 
@@ -67,7 +76,7 @@ namespace QTTabBarLib {
                     if(string.IsNullOrWhiteSpace(line)) {
                         continue;
                     }
-                    string[] parts = line.Split('	');
+                    string[] parts = SplitLegacyAware(line);
                     if(parts.Length < 2) {
                         continue;
                     }
@@ -90,17 +99,40 @@ namespace QTTabBarLib {
                 if(!File.Exists(TagDefinitionsPath)) {
                     return;
                 }
+                int version = 1;
                 foreach(string line in File.ReadAllLines(TagDefinitionsPath)) {
                     if(string.IsNullOrWhiteSpace(line)) {
                         continue;
                     }
-                    string[] parts = line.Split('	');
-                    if(parts.Length < 2) {
+                    if(line.StartsWith("#")) {
+                        if(line.StartsWith("#version=", StringComparison.OrdinalIgnoreCase)) {
+                            int.TryParse(line.Substring(9), NumberStyles.Integer, CultureInfo.InvariantCulture, out version);
+                        }
                         continue;
                     }
-                    Color color;
-                    if(TryParseColor(parts[1], out color)) {
-                        tagColors[parts[0]] = color;
+                    string[] parts = line.Split('\t');
+                    if(parts.Length < 2) {
+                        parts = SplitLegacyAware(line);
+                    }
+                    if(parts.Length == 0) {
+                        continue;
+                    }
+                    string name = (parts[0] ?? string.Empty).Trim();
+                    if(name.Length == 0) {
+                        continue;
+                    }
+                    TagDefinition definition = GetOrCreateDefinition(name);
+                    if(parts.Length > 1 && !string.IsNullOrWhiteSpace(parts[1])) {
+                        Color color;
+                        if(TryParseColor(parts[1], out color)) {
+                            definition.Color = color;
+                        }
+                    }
+                    if(version >= 2 && parts.Length > 2) {
+                        int priority;
+                        if(int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out priority)) {
+                            definition.Priority = priority;
+                        }
                     }
                 }
             }
@@ -112,26 +144,56 @@ namespace QTTabBarLib {
                 return;
             }
             Ensure();
-            bool changed = false;
-            foreach(string path in paths.Where(p => !string.IsNullOrWhiteSpace(p))) {
-                HashSet<string> set;
-                if(!tagAssignments.TryGetValue(path, out set)) {
-                    set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                    tagAssignments[path] = set;
+            HashSet<string> uniqueTags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            List<string> tagList = new List<string>();
+            foreach(string tag in tags) {
+                string trimmed = (tag ?? string.Empty).Trim();
+                if(trimmed.Length == 0) {
+                    continue;
                 }
-                foreach(string tag in tags) {
-                    string trimmed = (tag ?? string.Empty).Trim();
-                    if(trimmed.Length == 0) {
-                        continue;
+                if(uniqueTags.Add(trimmed)) {
+                    tagList.Add(trimmed);
+                }
+            }
+            if(uniqueTags.Count == 0) {
+                return;
+            }
+
+            bool anyAssignmentsChanged = false;
+            HashSet<string> affectedSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            List<string> affectedPaths = new List<string>();
+            foreach(string rawPath in paths) {
+                if(string.IsNullOrWhiteSpace(rawPath)) {
+                    continue;
+                }
+                string path = rawPath.Trim();
+                if(path.Length == 0) {
+                    continue;
+                }
+                HashSet<string> current;
+                if(!tagAssignments.TryGetValue(path, out current)) {
+                    current = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    tagAssignments[path] = current;
+                }
+                bool pathChanged = false;
+                foreach(string tag in tagList) {
+                    if(current.Add(tag)) {
+                        pathChanged = true;
                     }
-                    if(set.Add(trimmed)) {
-                        changed = true;
+                }
+                if(pathChanged) {
+                    anyAssignmentsChanged = true;
+                    if(UpdateVisualCacheForPath(path, current) && affectedSet.Add(path)) {
+                        affectedPaths.Add(path);
                     }
                 }
             }
-            if(changed) {
+
+            if(anyAssignmentsChanged) {
                 SaveAssignments();
-                BroadcastTagChanges();
+                if(affectedPaths.Count > 0) {
+                    BroadcastTagChanges(TagVisualChangedEventArgs.ForPaths(affectedPaths, tagList));
+                }
             }
         }
 
@@ -142,7 +204,7 @@ namespace QTTabBarLib {
             }
             HashSet<string> set;
             if(tagAssignments.TryGetValue(path, out set) && set.Count > 0) {
-                return string.Join(",", set.OrderBy(x => x));
+                return string.Join(",", set.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToArray());
             }
             return string.Empty;
         }
@@ -152,34 +214,24 @@ namespace QTTabBarLib {
             if(string.IsNullOrEmpty(path)) {
                 return false;
             }
-            HashSet<string> set;
-            return tagAssignments.TryGetValue(path, out set) && set.Count > 0;
+            return GetVisualState(path).HasTag;
         }
 
         public static Color? GetTagColorForPath(string path) {
-            Ensure();
-            if(string.IsNullOrEmpty(path)) {
-                return null;
-            }
-            HashSet<string> set;
-            if(!tagAssignments.TryGetValue(path, out set) || set.Count == 0) {
-                return null;
-            }
-            foreach(string tag in set.OrderBy(tag => tag)) {
-                Color color;
-                if(tagColors.TryGetValue(tag, out color)) {
-                    return color;
-                }
-            }
-            return null;
+            return GetVisualState(path).ForegroundColor;
         }
 
         public static bool TryGetTagColor(string tag, out Color color) {
             Ensure();
-            if(tag != null && tagColors.TryGetValue(tag, out color)) {
+            color = Color.Empty;
+            if(string.IsNullOrEmpty(tag)) {
+                return false;
+            }
+            TagDefinition definition;
+            if(tagDefinitions != null && tagDefinitions.TryGetValue(tag, out definition) && definition != null && definition.Color.HasValue) {
+                color = definition.Color.Value;
                 return true;
             }
-            color = Color.Empty;
             return false;
         }
 
@@ -188,20 +240,48 @@ namespace QTTabBarLib {
                 return;
             }
             Ensure();
+            tag = tag.Trim();
             bool changed = false;
+            TagDefinition definition;
+            if(!tagDefinitions.TryGetValue(tag, out definition)) {
+                if(!color.HasValue) {
+                    return;
+                }
+                definition = new TagDefinition(tag);
+                tagDefinitions[tag] = definition;
+            }
+
+            Color? previous = definition.Color;
             if(color.HasValue) {
-                Color existing;
-                if(!tagColors.TryGetValue(tag, out existing) || existing != color.Value) {
-                    tagColors[tag] = color.Value;
+                if(!previous.HasValue || previous.Value != color.Value) {
+                    definition.Color = color.Value;
                     changed = true;
                 }
             }
-            else if(tagColors.Remove(tag)) {
-                changed = true;
+            else {
+                if(previous.HasValue) {
+                    definition.Color = null;
+                    changed = true;
+                }
+                if(!definition.HasSerializableData) {
+                    tagDefinitions.Remove(tag);
+                }
             }
+
             if(changed) {
                 SaveDefinitions();
-                BroadcastTagChanges();
+                HashSet<string> affectedSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                List<string> affectedPaths = new List<string>();
+                foreach(KeyValuePair<string, HashSet<string>> assignment in tagAssignments) {
+                    if(assignment.Value != null && assignment.Value.Contains(tag)) {
+                        if(UpdateVisualCacheForPath(assignment.Key, assignment.Value) && affectedSet.Add(assignment.Key)) {
+                            affectedPaths.Add(assignment.Key);
+                        }
+                    }
+                }
+                if(affectedPaths.Count > 0) {
+                    BroadcastTagChanges(TagVisualChangedEventArgs.ForPaths(affectedPaths, new[] { tag }));
+                }
             }
         }
 
@@ -209,10 +289,10 @@ namespace QTTabBarLib {
             try {
                 StringBuilder builder = new StringBuilder();
                 foreach(KeyValuePair<string, HashSet<string>> pair in tagAssignments) {
-                    if(pair.Value.Count == 0) {
+                    if(pair.Value == null || pair.Value.Count == 0) {
                         continue;
                     }
-                    builder.Append(pair.Key).Append('	').Append(string.Join(",", pair.Value.OrderBy(tag => tag))).AppendLine();
+                    builder.Append(pair.Key).Append('\t').Append(string.Join(",", pair.Value.OrderBy(tag => tag, StringComparer.OrdinalIgnoreCase).ToArray())).AppendLine();
                 }
                 File.WriteAllText(TagsFilePath, builder.ToString());
             }
@@ -222,8 +302,18 @@ namespace QTTabBarLib {
         private static void SaveDefinitions() {
             try {
                 StringBuilder builder = new StringBuilder();
-                foreach(KeyValuePair<string, Color> pair in tagColors.OrderBy(kv => kv.Key)) {
-                    builder.Append(pair.Key).Append('	').Append(ColorTranslator.ToHtml(pair.Value)).AppendLine();
+                builder.AppendLine("#version=2");
+                foreach(KeyValuePair<string, TagDefinition> pair in tagDefinitions.OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase)) {
+                    TagDefinition definition = pair.Value;
+                    if(definition == null || !definition.HasSerializableData) {
+                        continue;
+                    }
+                    builder.Append(pair.Key).Append('\t');
+                    if(definition.Color.HasValue) {
+                        builder.Append(ColorTranslator.ToHtml(definition.Color.Value));
+                    }
+                    builder.Append('\t').Append(definition.Priority);
+                    builder.AppendLine();
                 }
                 File.WriteAllText(TagDefinitionsPath, builder.ToString());
             }
@@ -252,11 +342,179 @@ namespace QTTabBarLib {
             return false;
         }
 
-        private static void BroadcastTagChanges() {
+        internal static TagVisualState GetVisualState(string path) {
+            Ensure();
+            if(string.IsNullOrEmpty(path)) {
+                return TagVisualState.Empty;
+            }
+            TagVisualState state;
+            if(visualCache != null && visualCache.TryGetValue(path, out state)) {
+                return state;
+            }
+            state = ComputeVisualStateForPath(path);
+            if(state.HasTag && visualCache != null) {
+                visualCache[path] = state;
+            }
+            return state;
+        }
+
+        private static TagDefinition GetOrCreateDefinition(string tag) {
+            TagDefinition definition;
+            if(!tagDefinitions.TryGetValue(tag, out definition) || definition == null) {
+                definition = new TagDefinition(tag);
+                tagDefinitions[tag] = definition;
+            }
+            return definition;
+        }
+
+        private static TagVisualState ComputeVisualStateForPath(string path) {
+            HashSet<string> tags;
+            if(tagAssignments.TryGetValue(path, out tags)) {
+                return ComputeVisualState(tags);
+            }
+            return TagVisualState.Empty;
+        }
+
+        private static TagVisualState ComputeVisualState(HashSet<string> tags) {
+            if(tags == null || tags.Count == 0) {
+                return TagVisualState.Empty;
+            }
+            List<string> ordered = new List<string>(tags);
+            ordered.Sort(StringComparer.OrdinalIgnoreCase);
+            Color? color = ResolveColor(ordered);
+            int hash = ComputeVisualHash(ordered, color);
+            return new TagVisualState(true, color, hash);
+        }
+
+        private static Color? ResolveColor(IList<string> orderedTags) {
+            TagDefinition winner = null;
+            foreach(string tag in orderedTags) {
+                TagDefinition definition;
+                if(!tagDefinitions.TryGetValue(tag, out definition) || definition == null || !definition.Color.HasValue) {
+                    continue;
+                }
+                if(winner == null) {
+                    winner = definition;
+                    continue;
+                }
+                if(definition.Priority > winner.Priority) {
+                    winner = definition;
+                    continue;
+                }
+                if(definition.Priority == winner.Priority && string.Compare(definition.Name, winner.Name, StringComparison.OrdinalIgnoreCase) < 0) {
+                    winner = definition;
+                }
+            }
+            return winner != null ? winner.Color : (Color?)null;
+        }
+
+        private static int ComputeVisualHash(IList<string> orderedTags, Color? color) {
+            int hash = 17;
+            hash = (hash * 31) + (color.HasValue ? color.Value.ToArgb() : 0);
+            for(int i = 0; i < orderedTags.Count; i++) {
+                string tag = orderedTags[i] ?? string.Empty;
+                hash = (hash * 31) + StringComparer.OrdinalIgnoreCase.GetHashCode(tag);
+                TagDefinition definition;
+                if(tagDefinitions.TryGetValue(tag, out definition) && definition != null) {
+                    hash = (hash * 31) + definition.Priority;
+                }
+            }
+            return hash;
+        }
+
+        private static bool UpdateVisualCacheForPath(string path, HashSet<string> tags) {
+            if(visualCache == null) {
+                visualCache = new Dictionary<string, TagVisualState>(StringComparer.OrdinalIgnoreCase);
+            }
+            TagVisualState oldState;
+            visualCache.TryGetValue(path, out oldState);
+            TagVisualState newState = ComputeVisualState(tags);
+            if(newState.HasTag) {
+                visualCache[path] = newState;
+            }
+            else {
+                visualCache.Remove(path);
+            }
+            return oldState.VisualHash != newState.VisualHash;
+        }
+
+        private static void RebuildVisualCache() {
+            if(visualCache == null) {
+                visualCache = new Dictionary<string, TagVisualState>(StringComparer.OrdinalIgnoreCase);
+            }
+            else {
+                visualCache.Clear();
+            }
+            foreach(KeyValuePair<string, HashSet<string>> assignment in tagAssignments) {
+                if(assignment.Value == null || assignment.Value.Count == 0) {
+                    continue;
+                }
+                visualCache[assignment.Key] = ComputeVisualState(assignment.Value);
+            }
+        }
+
+        private static void BroadcastTagChanges(TagVisualChangedEventArgs args) {
+            TagVisualChangedEventArgs payload = args ?? TagVisualChangedEventArgs.Global;
+            try {
+                EventHandler<TagVisualChangedEventArgs> handler = TagVisualChanged;
+                if(handler != null) {
+                    handler(null, payload);
+                }
+            }
+            catch { }
             try {
                 InstanceManager.TabBarBroadcast(tabBar => tabBar.RefreshTagVisuals(), true);
             }
             catch { }
+        }
+
+        private static string[] SplitLegacyAware(string line) {
+            if(line == null) {
+                return new string[0];
+            }
+            string[] parts = line.Split('\t');
+            if(parts.Length > 1) {
+                return parts;
+            }
+            int index = -1;
+            int runLength = 0;
+            for(int i = 0; i < line.Length; i++) {
+                if(line[i] != ' ') {
+                    continue;
+                }
+                int j = i;
+                while(j < line.Length && line[j] == ' ') {
+                    j++;
+                }
+                runLength = j - i;
+                if(runLength >= 2) {
+                    index = i;
+                    break;
+                }
+                i = j - 1;
+            }
+            if(index < 0) {
+                return new[] { line };
+            }
+            string first = line.Substring(0, index);
+            string second = line.Substring(index + runLength);
+            return new[] { first, second };
+        }
+
+        private sealed class TagDefinition {
+            internal TagDefinition(string name) {
+                Name = name;
+            }
+
+            internal string Name { get; private set; }
+
+            internal Color? Color { get; set; }
+
+            internal int Priority { get; set; }
+
+            internal bool HasSerializableData {
+                get { return Color.HasValue || Priority != 0; }
+            }
         }
     }
 }

--- a/QTTabBar/TagVisualChangedEventArgs.cs
+++ b/QTTabBar/TagVisualChangedEventArgs.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace QTTabBarLib {
+    internal sealed class TagVisualChangedEventArgs : EventArgs {
+        private static readonly IList<string> EmptyList = new ReadOnlyCollection<string>(new string[0]);
+
+        internal static readonly TagVisualChangedEventArgs Global = new TagVisualChangedEventArgs(true, EmptyList, EmptyList, null, null);
+
+        private readonly HashSet<string> pathLookup;
+        private readonly HashSet<string> tagLookup;
+        private readonly IList<string> paths;
+        private readonly IList<string> tags;
+
+        private TagVisualChangedEventArgs(bool requiresFullRefresh, IList<string> paths, IList<string> tags, HashSet<string> pathLookup, HashSet<string> tagLookup) {
+            RequiresFullRefresh = requiresFullRefresh;
+            this.paths = paths ?? EmptyList;
+            this.tags = tags ?? EmptyList;
+            this.pathLookup = pathLookup;
+            this.tagLookup = tagLookup;
+        }
+
+        internal bool RequiresFullRefresh { get; private set; }
+
+        internal IList<string> Paths {
+            get { return paths; }
+        }
+
+        internal IList<string> Tags {
+            get { return tags; }
+        }
+
+        internal bool AffectsPath(string path) {
+            if(RequiresFullRefresh) {
+                return true;
+            }
+            if(string.IsNullOrEmpty(path) || pathLookup == null) {
+                return false;
+            }
+            return pathLookup.Contains(path);
+        }
+
+        internal bool MentionsTag(string tag) {
+            if(RequiresFullRefresh) {
+                return true;
+            }
+            if(string.IsNullOrEmpty(tag) || tagLookup == null) {
+                return false;
+            }
+            return tagLookup.Contains(tag);
+        }
+
+        internal static TagVisualChangedEventArgs ForPaths(IEnumerable<string> paths, IEnumerable<string> tags) {
+            List<string> pathList = new List<string>();
+            HashSet<string> pathSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if(paths != null) {
+                foreach(string candidate in paths) {
+                    string trimmed = (candidate ?? string.Empty).Trim();
+                    if(trimmed.Length == 0) {
+                        continue;
+                    }
+                    if(pathSet.Add(trimmed)) {
+                        pathList.Add(trimmed);
+                    }
+                }
+            }
+
+            List<string> tagList = new List<string>();
+            HashSet<string> tagSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if(tags != null) {
+                foreach(string candidate in tags) {
+                    string trimmed = (candidate ?? string.Empty).Trim();
+                    if(trimmed.Length == 0) {
+                        continue;
+                    }
+                    if(tagSet.Add(trimmed)) {
+                        tagList.Add(trimmed);
+                    }
+                }
+            }
+
+            if(pathList.Count == 0 && tagList.Count == 0) {
+                return Global;
+            }
+
+            IList<string> readOnlyPaths = pathList.Count > 0 ? (IList<string>)new ReadOnlyCollection<string>(pathList.ToArray()) : EmptyList;
+            IList<string> readOnlyTags = tagList.Count > 0 ? (IList<string>)new ReadOnlyCollection<string>(tagList.ToArray()) : EmptyList;
+            HashSet<string> lookupPaths = pathSet.Count > 0 ? pathSet : null;
+            HashSet<string> lookupTags = tagSet.Count > 0 ? tagSet : null;
+
+            return new TagVisualChangedEventArgs(false, readOnlyPaths, readOnlyTags, lookupPaths, lookupTags);
+        }
+    }
+}

--- a/QTTabBar/TagVisualState.cs
+++ b/QTTabBar/TagVisualState.cs
@@ -1,0 +1,20 @@
+using System.Drawing;
+
+namespace QTTabBarLib {
+    internal struct TagVisualState {
+        internal static readonly TagVisualState Empty = new TagVisualState(false, null, 0);
+
+        internal TagVisualState(bool hasTag, Color? foregroundColor, int visualHash)
+            : this() {
+            HasTag = hasTag;
+            ForegroundColor = foregroundColor;
+            VisualHash = visualHash;
+        }
+
+        public bool HasTag { get; private set; }
+
+        public Color? ForegroundColor { get; private set; }
+
+        internal int VisualHash { get; private set; }
+    }
+}

--- a/QTTabBar/TagsForm.cs
+++ b/QTTabBar/TagsForm.cs
@@ -6,8 +6,6 @@ using System.Windows.Forms;
 
 namespace QTTabBarLib {
     internal class TagsForm : Form {
-        private static Color? lastPickedColor;
-
         private readonly TextBox txtTags = new TextBox();
         private readonly Button btnApply = new Button();
         private readonly Button btnClose = new Button();
@@ -57,21 +55,25 @@ namespace QTTabBarLib {
                 return;
             }
 
-            Dictionary<string, Color> pendingColors = new Dictionary<string, Color>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, Color?> initialColors = new Dictionary<string, Color?>(StringComparer.OrdinalIgnoreCase);
             foreach(string tag in parsedTags) {
                 Color existing;
                 if(TagManager.TryGetTagColor(tag, out existing) && existing != Color.Empty) {
-                    continue;
+                    initialColors[tag] = existing;
                 }
-                if(!PromptForColor(tag, out existing)) {
-                    return;
+                else {
+                    initialColors[tag] = null;
                 }
-                pendingColors[tag] = existing;
+            }
+
+            Dictionary<string, Color?> updatedColors;
+            if(!TagColorEditorForm.TryEditColors(this, parsedTags, initialColors, out updatedColors)) {
+                return;
             }
 
             try {
                 TagManager.AddTags(targets, parsedTags);
-                foreach(KeyValuePair<string, Color> pair in pendingColors) {
+                foreach(KeyValuePair<string, Color?> pair in updatedColors) {
                     TagManager.SetTagColor(pair.Key, pair.Value);
                 }
                 Close();
@@ -91,21 +93,5 @@ namespace QTTabBarLib {
             }
         }
 
-        private bool PromptForColor(string tag, out Color color) {
-            color = Color.Empty;
-            using(ColorDialog dialog = new ColorDialog()) {
-                dialog.FullOpen = true;
-                if(lastPickedColor.HasValue) {
-                    dialog.Color = lastPickedColor.Value;
-                }
-                dialog.CustomColors = null;
-                if(dialog.ShowDialog(this) != DialogResult.OK) {
-                    return false;
-                }
-                color = dialog.Color;
-                lastPickedColor = color;
-                return true;
-            }
-        }
     }
 }

--- a/QTTabBar/TreeViewWrapper.cs
+++ b/QTTabBar/TreeViewWrapper.cs
@@ -32,7 +32,14 @@ namespace QTTabBarLib {
         private NativeWindowController treeController;
         private NativeWindowController parentController;
         private bool fPreventSelChange;
-        private readonly Dictionary<IntPtr, Color?> tagColorCache = new Dictionary<IntPtr, Color?>();
+        private readonly Dictionary<IntPtr, TreeNodeTagVisual> tagColorCache = new Dictionary<IntPtr, TreeNodeTagVisual>();
+        private readonly EventHandler<TagVisualChangedEventArgs> tagChangedHandler;
+
+        private struct TreeNodeTagVisual {
+            public string Path;
+            public Color? Color;
+            public int VisualHash;
+        }
 
         public TreeViewWrapper(IntPtr hwnd, INameSpaceTreeControl treeControl) {
             QTUtility2.log("TreeViewWrapper init");
@@ -41,6 +48,11 @@ namespace QTTabBarLib {
             treeController.MessageCaptured += TreeControl_MessageCaptured;
             parentController = new NativeWindowController(PInvoke.GetParent(hwnd));
             parentController.MessageCaptured += ParentControl_MessageCaptured;
+            tagChangedHandler = TagManager_TagVisualChanged;
+            try {
+                TagManager.TagVisualChanged += tagChangedHandler;
+            }
+            catch { }
         }
 
         private bool HandleClick(Point pt, Keys modifierKeys, bool middle) {
@@ -93,6 +105,7 @@ namespace QTTabBarLib {
                         Marshal.ReleaseComObject(treeControl);
                         treeControl = null;
                     }
+                    UnsubscribeTagNotifications();
                     tagColorCache.Clear();
                     break;
             }
@@ -158,17 +171,19 @@ namespace QTTabBarLib {
 
         private Color? ResolveTagColor(NMTVCUSTOMDRAW draw) {
             IntPtr handle = draw.nmcd.dwItemSpec;
-            Color? cached;
-            if(tagColorCache.TryGetValue(handle, out cached)) {
-                return cached;
-            }
-            Color? color = null;
             string path = TryGetPathFromDraw(draw);
-            if(!string.IsNullOrEmpty(path)) {
-                color = TagManager.GetTagColorForPath(path);
+            if(string.IsNullOrEmpty(path)) {
+                tagColorCache[handle] = new TreeNodeTagVisual { Path = null, Color = null, VisualHash = 0 };
+                return null;
             }
-            tagColorCache[handle] = color;
-            return color;
+            TagVisualState state = TagManager.GetVisualState(path);
+            TreeNodeTagVisual cached;
+            if(tagColorCache.TryGetValue(handle, out cached) && !string.IsNullOrEmpty(cached.Path) && string.Equals(cached.Path, path, StringComparison.OrdinalIgnoreCase) && cached.VisualHash == state.VisualHash) {
+                return cached.Color;
+            }
+            TreeNodeTagVisual visual = new TreeNodeTagVisual { Path = path, Color = state.ForegroundColor, VisualHash = state.VisualHash };
+            tagColorCache[handle] = visual;
+            return visual.Color;
         }
 
         private string TryGetPathFromDraw(NMTVCUSTOMDRAW draw) {
@@ -212,6 +227,51 @@ namespace QTTabBarLib {
             }
         }
 
+        private void TagManager_TagVisualChanged(object sender, TagVisualChangedEventArgs e) {
+            if(e == null) {
+                e = TagVisualChangedEventArgs.Global;
+            }
+            bool requireRefresh = e.RequiresFullRefresh;
+            if(!requireRefresh && tagColorCache.Count > 0) {
+                List<IntPtr> toRemove = null;
+                foreach(KeyValuePair<IntPtr, TreeNodeTagVisual> entry in tagColorCache) {
+                    string cachedPath = entry.Value.Path;
+                    if(string.IsNullOrEmpty(cachedPath)) {
+                        continue;
+                    }
+                    if(e.AffectsPath(cachedPath)) {
+                        if(toRemove == null) {
+                            toRemove = new List<IntPtr>();
+                        }
+                        toRemove.Add(entry.Key);
+                    }
+                }
+                if(toRemove != null) {
+                    foreach(IntPtr key in toRemove) {
+                        tagColorCache.Remove(key);
+                    }
+                    requireRefresh = true;
+                }
+            }
+            if(requireRefresh) {
+                if(e.RequiresFullRefresh) {
+                    tagColorCache.Clear();
+                }
+                if(treeController != null && treeController.Handle != IntPtr.Zero) {
+                    PInvoke.InvalidateRect(treeController.Handle, IntPtr.Zero, true);
+                }
+            }
+        }
+
+        private void UnsubscribeTagNotifications() {
+            if(tagChangedHandler != null) {
+                try {
+                    TagManager.TagVisualChanged -= tagChangedHandler;
+                }
+                catch { }
+            }
+        }
+
         #region IDisposable Members
 
         public void Dispose() {
@@ -221,6 +281,7 @@ namespace QTTabBarLib {
                 Marshal.ReleaseComObject(treeControl);
                 treeControl = null;
             }
+            UnsubscribeTagNotifications();
             fDisposed = true;
         }
 

--- a/QTTabBar/TreeViewWrapper.cs
+++ b/QTTabBar/TreeViewWrapper.cs
@@ -16,6 +16,7 @@
 //    along with QTTabBar.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
@@ -31,6 +32,7 @@ namespace QTTabBarLib {
         private NativeWindowController treeController;
         private NativeWindowController parentController;
         private bool fPreventSelChange;
+        private readonly Dictionary<IntPtr, Color?> tagColorCache = new Dictionary<IntPtr, Color?>();
 
         public TreeViewWrapper(IntPtr hwnd, INameSpaceTreeControl treeControl) {
             QTUtility2.log("TreeViewWrapper init");
@@ -91,6 +93,7 @@ namespace QTTabBarLib {
                         Marshal.ReleaseComObject(treeControl);
                         treeControl = null;
                     }
+                    tagColorCache.Clear();
                     break;
             }
             return false;
@@ -98,9 +101,15 @@ namespace QTTabBarLib {
 
         private bool ParentControl_MessageCaptured(ref Message msg) {
             if(msg.Msg == WM.NOTIFY) {
-                
+
                 NMHDR nmhdr = (NMHDR)Marshal.PtrToStructure(msg.LParam, typeof(NMHDR));
                 switch(nmhdr.code) {
+                    case -12: /* NM_CUSTOMDRAW */
+                        if(HandleCustomDraw(ref msg)) {
+                            return true;
+                        }
+                        break;
+
                     case -2: /* NM_CLICK */
                         if(Control.ModifierKeys != Keys.None) {
                             QTUtility2.log("TreeViewWrapper ParentControl_MessageCaptured WM.NOTIFY NM_CLICK");
@@ -124,6 +133,83 @@ namespace QTTabBarLib {
                 }
             }
             return false;
+        }
+
+        private bool HandleCustomDraw(ref Message msg) {
+            NMTVCUSTOMDRAW draw = (NMTVCUSTOMDRAW)Marshal.PtrToStructure(msg.LParam, typeof(NMTVCUSTOMDRAW));
+            switch(draw.nmcd.dwDrawStage) {
+                case CDDS.PREPAINT:
+                    msg.Result = (IntPtr)CDRF.NOTIFYITEMDRAW;
+                    return true;
+
+                case CDDS.ITEMPREPAINT:
+                    Color? textColor = ResolveTagColor(draw);
+                    if(textColor.HasValue) {
+                        draw.clrText = QTUtility2.MakeCOLORREF(textColor.Value);
+                        Marshal.StructureToPtr(draw, msg.LParam, false);
+                        msg.Result = (IntPtr)CDRF.NEWFONT;
+                        return true;
+                    }
+                    break;
+            }
+            msg.Result = IntPtr.Zero;
+            return false;
+        }
+
+        private Color? ResolveTagColor(NMTVCUSTOMDRAW draw) {
+            IntPtr handle = draw.nmcd.dwItemSpec;
+            Color? cached;
+            if(tagColorCache.TryGetValue(handle, out cached)) {
+                return cached;
+            }
+            Color? color = null;
+            string path = TryGetPathFromDraw(draw);
+            if(!string.IsNullOrEmpty(path)) {
+                color = TagManager.GetTagColorForPath(path);
+            }
+            tagColorCache[handle] = color;
+            return color;
+        }
+
+        private string TryGetPathFromDraw(NMTVCUSTOMDRAW draw) {
+            if(treeControl == null) {
+                return null;
+            }
+            Point pt = new Point((draw.nmcd.rc.left + draw.nmcd.rc.right) / 2, (draw.nmcd.rc.top + draw.nmcd.rc.bottom) / 2);
+            IShellItem item = null;
+            try {
+                if(treeControl.HitTest(ref pt, out item) == 0 && item != null) {
+                    IntPtr pidl;
+                    if(PInvoke.SHGetIDListFromObject(item, out pidl) == 0) {
+                        try {
+                            using(IDLWrapper wrapper = new IDLWrapper(pidl)) {
+                                if(wrapper.Available && wrapper.HasPath) {
+                                    return wrapper.Path;
+                                }
+                            }
+                        }
+                        finally {
+                            if(pidl != IntPtr.Zero) {
+                                PInvoke.CoTaskMemFree(pidl);
+                            }
+                        }
+                    }
+                }
+            }
+            catch { }
+            finally {
+                if(item != null) {
+                    Marshal.ReleaseComObject(item);
+                }
+            }
+            return null;
+        }
+
+        internal void RefreshTagColors() {
+            tagColorCache.Clear();
+            if(treeController != null && treeController.Handle != IntPtr.Zero) {
+                PInvoke.InvalidateRect(treeController.Handle, IntPtr.Zero, true);
+            }
         }
 
         #region IDisposable Members


### PR DESCRIPTION
## Summary
- add git status overlay icons with glyphs and cacheable image keys, tracking base icon state in tabs
- introduce a tag color editor dialog and propagate tag colors into the list view and navigation tree custom draw paths
- redesign tab group islands with accent rails, drag-and-drop membership, and refreshed project metadata for new helper files

## Testing
- msbuild "QTTabBar Rebirth.sln" /t:Build /p:Configuration=Release *(fails: msbuild not available in container)*
- dotnet build "QTTabBar Rebirth.sln" -c Release *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf7396a3c083308d858541917140ad