### PR TITLE
Fix extra brace causing OpenGroup compilation error

### DIFF
--- a/QTTabBar/QTTabBarClass.cs
+++ b/QTTabBar/QTTabBarClass.cs
@@ -6236,7 +6236,6 @@ namespace QTTabBarLib {
             if(assignedTabs.Count > 0) {
                 tabControl1.AssignGroupTabs(groupName, assignedTabs);
             }
-            }
         }
 
         private bool OpenNewTab(string path, bool blockSelecting = false, bool fForceNew = false) {


### PR DESCRIPTION
## Summary
- remove an extra closing brace at the end of `QTTabBarClass.OpenGroup`, keeping the subsequent methods inside the class definition
- ensure assigned group tabs are still registered while preserving correct block structure

## Testing
- `dotnet build "QTTabBar Rebirth.sln" -c Release` *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf8d0293408330b6a62a3d65d625d6