### PR TITLE
Fix OptionsDialog tree helper method definition

### DIFF
--- a/QTTabBar/OptionsDialog/OptionsDialog.xaml.cs
+++ b/QTTabBar/OptionsDialog/OptionsDialog.xaml.cs
@@ -879,7 +879,7 @@ namespace QTTabBarLib {
         }
 
         // Utility method to move nodes up and down in a TreeView.
-}
+        protected static void UpDownOnTreeView(TreeView tvw, bool up, bool traverseFolders) {
             ITreeViewItem sel = tvw.SelectedItem as ITreeViewItem;
             if(sel == null) return;
             IList list = sel.ParentList;


### PR DESCRIPTION
## Summary
- reintroduce the OptionsDialogTab.UpDownOnTreeView helper signature so the tree movement logic is defined inside the class
- keep the helper scoped to the dialog tab base class and ensure the file terminates with a newline

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d0104a4bcc8330a6edc224031a509d