### PR TITLE
Fix commented block and clean Options dialog update

### DIFF
--- a/QTTabBar/OptionsDialog/OptionsDialog.xaml.cs
+++ b/QTTabBar/OptionsDialog/OptionsDialog.xaml.cs
@@ -268,8 +268,10 @@ namespace QTTabBarLib {
             this.WindowStartupLocation = WindowStartupLocation.CenterScreen;
 
             // 双屏幕打开逻辑问题
-            /*var bMulScreens = Screen.AllScreens.Length > 1;
-            var screenWidth = 0;
+            // var bMulScreens = Screen.AllScreens.Length > 1;
+            // var screenWidth = 0;
+        }
+
         private void generateInitConfig() {
             if(WorkingConfig == null) {
                 return;
@@ -325,46 +327,6 @@ namespace QTTabBarLib {
                 return Convert.ToInt32(value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
             }
             return Convert.ToString(value, CultureInfo.InvariantCulture);
-        }
-        #endregion
-
-        private void UpdateOptions() {
-            foreach(OptionsDialogTab tab in tabbedPanel.Items) {
-                tab.CommitConfig();
-            }
-
-                        if (null != po)
-                            if (_configProperty.PropertyType == typeof(String))
-                            {
-                                b.Append("\"").Append(_configProperty.GetValue(_configObj, null)).Append("\"");
-                            }
-                            else if (_configProperty.PropertyType.IsArray) /* property type is array. */
-                            {
-                                /* join like this "new System.Int32[] {1, 2, 3}; " */
-                                Array arr = (Array)_configProperty.GetValue(_configObj, null);
-                                b.Append("new ").Append(arr.GetType()).Append("{");
-                                for (int i = 0; i < arr.Length; i++)
-                                {
-                                    b.Append(arr.GetValue(i)).Append(",");
-                                }
-                                b.Append("}");
-                            }
-                            else
-                            {
-                                b.Append(_configProperty.GetValue(_configObj, null).ToString().ToLower());
-                            }
-                        else
-                        {
-                            b.Append("null");
-                        }
-                        b.Append(";");
-                        sw.WriteLine(_configProperty.Name + "\t=\t" + b.ToString());
-                    }// end for each 
-                }
-                sw.WriteLine();
-            }
-            sw.Flush();
-            sw.Close();         
         }
         #endregion
 
@@ -879,7 +841,7 @@ namespace QTTabBarLib {
         }
 
         // Utility method to move nodes up and down in a TreeView.
-}
+        protected static void UpDownOnTreeView(TreeView tvw, bool up, bool traverseFolders) {
             ITreeViewItem sel = tvw.SelectedItem as ITreeViewItem;
             if(sel == null) return;
             IList list = sel.ParentList;


### PR DESCRIPTION
## Summary
- convert the multi-screen note in `setByQwop` to line comments and close the helper method properly
- remove the orphaned serialization snippet and extra `UpdateOptions` stub so only the real update routine remains

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d0104a4bcc8330a6edc224031a509d