### PR TITLE
Restore rename prompt helpers and string resource wrapper

### DIFF
--- a/QTTabBar/Interop/ShellMethods.cs
+++ b/QTTabBar/Interop/ShellMethods.cs
@@ -22,6 +22,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Media;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Text;
@@ -98,6 +99,99 @@ namespace QTTabBarLib.Interop {
             }
             Marshal.Copy(data, 0, zero, length);
             return zero;
+        }
+
+        public static void PromptRename(byte[] idl, IntPtr explorerHandle, string failureMessage) {
+            if(idl == null || idl.Length == 0) {
+                return;
+            }
+
+            try {
+                using(IDLWrapper wrapper = new IDLWrapper(idl, false)) {
+                    if(!wrapper.Available) {
+                        return;
+                    }
+
+                    string path = wrapper.Path;
+                    if(string.IsNullOrEmpty(path)) {
+                        return;
+                    }
+
+                    string directory = Path.GetDirectoryName(path);
+                    string name = Path.GetFileName(path);
+                    if(string.IsNullOrEmpty(directory) || string.IsNullOrEmpty(name)) {
+                        return;
+                    }
+
+                    object shell = null;
+                    object folder = null;
+                    object item = null;
+
+                    try {
+                        Type shellType = Type.GetTypeFromProgID("Shell.Application");
+                        if(shellType == null) {
+                            return;
+                        }
+
+                        shell = Activator.CreateInstance(shellType);
+                        folder = shellType.InvokeMember(
+                                "NameSpace",
+                                BindingFlags.InvokeMethod,
+                                null,
+                                shell,
+                                new object[] { directory });
+
+                        if(folder == null) {
+                            return;
+                        }
+
+                        if(explorerHandle != IntPtr.Zero) {
+                            PInvoke.SetForegroundWindow(explorerHandle);
+                        }
+
+                        Type folderType = folder.GetType();
+                        item = folderType.InvokeMember(
+                                "ParseName",
+                                BindingFlags.InvokeMethod,
+                                null,
+                                folder,
+                                new object[] { name });
+
+                        if(item == null) {
+                            return;
+                        }
+
+                        Type itemType = item.GetType();
+                        itemType.InvokeMember(
+                                "InvokeVerb",
+                                BindingFlags.InvokeMethod,
+                                null,
+                                item,
+                                new object[] { "rename" });
+                    }
+                    finally {
+                        ReleaseComObject(item);
+                        ReleaseComObject(folder);
+                        ReleaseComObject(shell);
+                    }
+                }
+            }
+            catch(Exception exception) {
+                QTUtility2.MakeErrorLog(exception, "ShellMethods.PromptRename");
+                if(!string.IsNullOrEmpty(failureMessage)) {
+                    try {
+                        MessageBox.Show(failureMessage, "QTTabBar", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    }
+                    catch {
+                    }
+                }
+            }
+        }
+
+        private static void ReleaseComObject(object instance) {
+            if(instance != null && Marshal.IsComObject(instance)) {
+                Marshal.FinalReleaseComObject(instance);
+            }
         }
 
         public static bool DeleteFile(List<string> lstPaths, bool fShiftKey, IntPtr hwnd) {

--- a/QTTabBar/OptionsDialog/OptionsDialog.xaml.cs
+++ b/QTTabBar/OptionsDialog/OptionsDialog.xaml.cs
@@ -200,18 +200,7 @@ namespace QTTabBarLib {
                 };
                 foreach(OptionsDialogTab tab in tabbedPanel.Items) {
                     tab.WorkingConfig = WorkingConfig;
-
-                    new Options11_ButtonBar     { Index = i++},
-
-                    new Options12_Plugins       { Index = i++},
-
-                    new Options13_Language      { Index = i++},
-
-                    new Options15_Sessions      { Index = i++},
-
-                    new Options14_About         { Index = i}
-
-                };
+                }
 
                // QTUtility2.log("tabbedPanel.ItemsSource end");    
 
@@ -268,8 +257,10 @@ namespace QTTabBarLib {
             this.WindowStartupLocation = WindowStartupLocation.CenterScreen;
 
             // 双屏幕打开逻辑问题
-            /*var bMulScreens = Screen.AllScreens.Length > 1;
-            var screenWidth = 0;
+            // var bMulScreens = Screen.AllScreens.Length > 1;
+            // var screenWidth = 0;
+        }
+
         private void generateInitConfig() {
             if(WorkingConfig == null) {
                 return;
@@ -325,46 +316,6 @@ namespace QTTabBarLib {
                 return Convert.ToInt32(value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
             }
             return Convert.ToString(value, CultureInfo.InvariantCulture);
-        }
-        #endregion
-
-        private void UpdateOptions() {
-            foreach(OptionsDialogTab tab in tabbedPanel.Items) {
-                tab.CommitConfig();
-            }
-
-                        if (null != po)
-                            if (_configProperty.PropertyType == typeof(String))
-                            {
-                                b.Append("\"").Append(_configProperty.GetValue(_configObj, null)).Append("\"");
-                            }
-                            else if (_configProperty.PropertyType.IsArray) /* property type is array. */
-                            {
-                                /* join like this "new System.Int32[] {1, 2, 3}; " */
-                                Array arr = (Array)_configProperty.GetValue(_configObj, null);
-                                b.Append("new ").Append(arr.GetType()).Append("{");
-                                for (int i = 0; i < arr.Length; i++)
-                                {
-                                    b.Append(arr.GetValue(i)).Append(",");
-                                }
-                                b.Append("}");
-                            }
-                            else
-                            {
-                                b.Append(_configProperty.GetValue(_configObj, null).ToString().ToLower());
-                            }
-                        else
-                        {
-                            b.Append("null");
-                        }
-                        b.Append(";");
-                        sw.WriteLine(_configProperty.Name + "\t=\t" + b.ToString());
-                    }// end for each 
-                }
-                sw.WriteLine();
-            }
-            sw.Flush();
-            sw.Close();         
         }
         #endregion
 
@@ -879,7 +830,7 @@ namespace QTTabBarLib {
         }
 
         // Utility method to move nodes up and down in a TreeView.
-}
+        protected static void UpDownOnTreeView(TreeView tvw, bool up, bool traverseFolders) {
             ITreeViewItem sel = tvw.SelectedItem as ITreeViewItem;
             if(sel == null) return;
             IList list = sel.ParentList;

--- a/QTTabBar/QTTabBar.csproj
+++ b/QTTabBar/QTTabBar.csproj
@@ -222,6 +222,7 @@
     </Compile>
     <Compile Include="FreeBitmap.cs" />
     <Compile Include="Graphic.cs" />
+    <Compile Include="StringResources.cs" />
     <Compile Include="ICommandInvokerWindow.cs" />
     <Compile Include="TabSessionManager.cs" />
     <Compile Include="Interop\CoreErrorHelper.cs" />

--- a/QTTabBar/QTTabBarClass.cs
+++ b/QTTabBar/QTTabBarClass.cs
@@ -1382,7 +1382,8 @@ namespace QTTabBarLib {
 
         private bool CanRenameTabFolder(QTabItem tab)
         {
-            if(!TryCreateWrapperForTab(tab, out IDLWrapper wrapper)) {
+            IDLWrapper wrapper;
+            if(!TryCreateWrapperForTab(tab, out wrapper)) {
                 return false;
             }
             using(wrapper) {
@@ -1399,7 +1400,8 @@ namespace QTTabBarLib {
 
         private void PromptRenameForTab(QTabItem tab)
         {
-            if(!TryCreateWrapperForTab(tab, out IDLWrapper wrapper)) {
+            IDLWrapper wrapper;
+            if(!TryCreateWrapperForTab(tab, out wrapper)) {
                 return;
             }
             using(wrapper) {
@@ -1704,8 +1706,12 @@ namespace QTTabBarLib {
                     tab.UpdateTagColor(false);
                 }
                 tabControl1.Invalidate();
-                listView?.RefreshTagColors();
-                treeViewWrapper?.RefreshTagColors();
+                if(listView != null) {
+                    listView.RefreshTagColors();
+                }
+                if(treeViewWrapper != null) {
+                    treeViewWrapper.RefreshTagColors();
+                }
             }
             catch { }
         }
@@ -2868,7 +2874,8 @@ namespace QTTabBarLib {
             if(tabMouseOn == null) {
                 return 1;
             }
-            if(!TryCreateWrapperForTab(tabMouseOn, out IDLWrapper wrapper)) {
+            IDLWrapper wrapper;
+            if(!TryCreateWrapperForTab(tabMouseOn, out wrapper)) {
                 return -1;
             }
             using(wrapper) {
@@ -2962,7 +2969,8 @@ namespace QTTabBarLib {
                 ShowToolTipForDD(mouseOnTab, -1, e.KeyState);
                 return;
             }
-            if(!TryCreateWrapperForTab(mouseOnTab, out IDLWrapper wrapper)) {
+            IDLWrapper wrapper;
+            if(!TryCreateWrapperForTab(mouseOnTab, out wrapper)) {
                 HideToolTipForDD();
                 return;
             }

--- a/QTTabBar/StringResources.cs
+++ b/QTTabBar/StringResources.cs
@@ -1,0 +1,139 @@
+//    This file is part of QTTabBar, a shell extension for Microsoft
+//    Windows Explorer.
+//    Copyright (C) 2007-2022  Quizo, Paul Accisano, indiff
+//
+//    QTTabBar is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    QTTabBar is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with QTTabBar.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Globalization;
+
+namespace QTTabBarLib {
+    internal static class StringResources {
+        private static readonly object SyncRoot = new object();
+        private static bool initialized;
+
+        public static void Initialize() {
+            EnsureInitialized();
+        }
+
+        public static string Pluralize(string pattern, int count) {
+            if(string.IsNullOrEmpty(pattern)) {
+                return string.Empty;
+            }
+
+            string[] forms = pattern.Split(new[] { ';' }, StringSplitOptions.None);
+            string format;
+            if(forms.Length <= 1) {
+                format = forms[0];
+            }
+            else {
+                format = count == 1 ? forms[0] : forms[Math.Min(forms.Length - 1, 1)];
+            }
+
+            try {
+                return string.Format(CultureInfo.CurrentCulture, format, count);
+            }
+            catch(FormatException) {
+                return format;
+            }
+        }
+
+        public static class Dialogs {
+            private static readonly string[] Fallback = {
+                "Another item with the same name already exists.",
+                "Please choose a different name.",
+                "Rename"
+            };
+
+            public static string[] _Dialog {
+                get { return GetStrings("Dialogs", Fallback); }
+            }
+        }
+
+        public static class Global {
+            private static readonly string[] NotifyIconFallback = {
+                "Explorer",
+                "{0} windows",
+                "Restore all",
+                "Close all"
+            };
+
+            private static readonly string[] ViewSyncFallback = {
+                "Off",
+                "Navigation",
+                "Scroll",
+                "Navigation synchronization canceled."
+            };
+
+            public static string[] NotifyIcon {
+                get { return GetStrings("TrayIcon", NotifyIconFallback); }
+            }
+
+            public static string[] ViewSync {
+                get { return GetStrings("ViewSync", ViewSyncFallback); }
+            }
+        }
+
+        private static void EnsureInitialized() {
+            if(initialized) {
+                return;
+            }
+
+            lock(SyncRoot) {
+                if(initialized) {
+                    return;
+                }
+
+                try {
+                    QTUtility.ValidateTextResources();
+                }
+                catch(Exception ex) {
+                    QTUtility2.MakeErrorLog(ex, "StringResources.Initialize");
+                }
+
+                initialized = true;
+            }
+        }
+
+        private static string[] GetStrings(string key, string[] fallback) {
+            EnsureInitialized();
+
+            var dictionary = QTUtility.TextResourcesDic;
+            if(dictionary == null) {
+                return CloneArray(fallback);
+            }
+
+            string[] values;
+            if(!dictionary.TryGetValue(key, out values) || values == null || values.Length == 0) {
+                return CloneArray(fallback);
+            }
+
+            if(fallback != null && values.Length < fallback.Length) {
+                string[] extended = new string[fallback.Length];
+                Array.Copy(values, extended, values.Length);
+                Array.Copy(fallback, values.Length, extended, fallback.Length - values.Length);
+                return extended;
+            }
+
+            return CloneArray(values);
+        }
+
+        private static string[] CloneArray(string[] source) {
+            if(source == null || source.Length == 0) {
+                return new string[0];
+            }
+            return (string[])source.Clone();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- remove the stray Options dialog tab initializers that leaked into the foreach loop so the constructor compiles again
- replace null-conditional and inline out-variable usage with legacy-safe patterns in `QTTabBarClass`
- implement `ShellMethods.PromptRename` so tab rename commands invoke the Shell rename verb instead of failing with missing method errors
- add a `StringResources` wrapper backed by `QTUtility.TextResourcesDic` to provide the localized strings referenced throughout the explorer manager code

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d0104a4bcc8330a6edc224031a509d