### PR TITLE
Remove duplicate menu fields hiding TabBarBase members

### DIFF
--- a/QTTabBar/QTTabBarClass.cs
+++ b/QTTabBar/QTTabBarClass.cs
@@ -125,42 +125,7 @@ namespace QTTabBarLib {
         
         
         private TreeViewWrapper treeViewWrapper;
-        // 添加到分组
-        private ToolStripMenuItem tsmiAddToGroup;
-        private ToolStripMenuItem tsmiBrowseFolder;
-        private ToolStripMenuItem tsmiCloneThis;
         private ToolStripMenuItem tsmiRenameFolder;
-        private ToolStripMenuItem tsmiClose;
-        private ToolStripMenuItem tsmiCloseAllButCurrent;
-        private ToolStripMenuItem tsmiCloseAllButThis;
-        private ToolStripMenuItem tsmiCloseLeft;
-        private ToolStripMenuItem tsmiCloseRight;
-        private ToolStripMenuItem tsmiCloseWindow;
-        private ToolStripMenuItem tsmiCopy;
-        private ToolStripMenuItem tsmiCreateGroup;
-        private ToolStripMenuItem tsmiCreateWindow;
-        private ToolStripMenuItem tsmiExecuted;
-        private ToolStripMenuItem tsmiGroups;
-        private ToolStripMenuItem tsmiHistory;
-        private ToolStripMenuItem tsmiLastActiv;
-        private ToolStripMenuItem tsmiLockThis;
-        private ToolStripMenuItem tsmiLockToolbar;
-        private ToolStripMenuItem tsmiMergeWindows;
-        private ToolStripMenuItem tsmiOption;
-        private ToolStripMenuItem tsmiProp;
-        private ToolStripMenuItem tsmiTabOrder;
-        private ToolStripMenuItem tsmiUndoClose;
-
-        /*add by qwop 2012.07.13#1#*/
-        private ToolStripMenuItem tsmiOpenCmd;
-        private ToolStripMenuItem enableApiHook;
-        /*add by qwop 2012.07.13#1#*/
-
-        private ToolStripSeparator tssep_Sys1;
-        private ToolStripSeparator tssep_Sys2;
-        private ToolStripSeparator tssep_Tab1;
-        private ToolStripSeparator tssep_Tab2;
-        private ToolStripSeparator tssep_Tab3;
         private readonly int WM_NEWTREECONTROL = PInvoke.RegisterWindowMessage("QTTabBar_NewTreeControl");
         private readonly int WM_BROWSEOBJECT = PInvoke.RegisterWindowMessage("QTTabBar_BrowseObject");
         private readonly int WM_HEADERINALLVIEWS = PInvoke.RegisterWindowMessage("QTTabBar_HeaderInAllViews");


### PR DESCRIPTION
## Summary
- remove redundant ToolStrip menu fields from `QTTabBarClass`
- rely on the inherited `TabBarBase` definitions to eliminate CS0108 warnings

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d021a29960833085cabbbcbf80e3e9